### PR TITLE
Classic Editor plugin: Update button not recaptioned with Edit (Classic)

### DIFF
--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -928,9 +928,9 @@ class Revisionary
 		}
 
 		if (class_exists('Classic_Editor')) {
-			if (isset($_REQUEST['classic-editor__forget']) && isset($_REQUEST['classic'])) {
+			if (isset($_REQUEST['classic-editor__forget']) && (isset($_REQUEST['classic']) || isset($_REQUEST['classic-editor']))) {
 				return false;
-			} elseif (isset($_REQUEST['classic-editor__forget']) && !isset($_REQUEST['classic'])) {
+			} elseif (isset($_REQUEST['classic-editor__forget']) && !isset($_REQUEST['classic']) && !isset($_REQUEST['classic-editor'])) {
 				return true;
 			} elseif (get_option('classic-editor-allow-users') === 'allow') {
 				if ($post_id = rvy_detect_post_id()) {


### PR DESCRIPTION
When editing a Revisor edits a post using the "Edit (Classic)" link, the Update button is not recaptioned to "Submit Revision"

Fixes #101 