### PR TITLE
Scheduled revisions could not be published by "Publish Now" preview link

### DIFF
--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -463,7 +463,12 @@ function rvy_apply_revision( $revision_id, $actual_revision_status = '' ) {
 
 	$revision_content = $update['post_content'];
 
+	global $revisionary;
+	
+	$revisionary->disable_revision_trigger = true;
 	$post_id = wp_update_post( $update );
+	$revisionary->disable_revision_trigger = false;
+
 	if ( ! $post_id || is_wp_error( $post_id ) ) {
 		return $post_id;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -100,8 +100,9 @@ Follow PublishPress on [Facebook](https://www.facebook.com/publishpress), [Twitt
 
 == Changelog ==
 
-= 2.3.9-beta2 =
-* Fixed : Schedule revisions caused post to be unpublished under some conditions
+= 2.3.9-beta3 =
+* Fixed : Scheduled revision publication failed under some conditions, caused post to be unpublished
+* Fixed : Scheduled revisions could not be published ahead of schedule using "Publish Now" link on preview (since 2.3.4)
 * API : New filter 'revisionary_apply_revision_data' to adjust standard revision fields prior to publication
 
 = 2.3.8 - 30 Jul 2020 =

--- a/revision-creation_rvy.php
+++ b/revision-creation_rvy.php
@@ -21,6 +21,10 @@ class RevisionCreation {
 			global $revisionary;
 		}
 
+		if ($revisionary->disable_revision_trigger) {
+			return $data;
+		}
+
         if ( isset($_POST['wp-preview']) && ( 'dopreview' == $_POST['wp-preview'] ) ) {
             return $data;
         }
@@ -130,6 +134,10 @@ class RevisionCreation {
 			global $revisionary;
 		}
         
+		if ($revisionary->disable_revision_trigger) {
+			return $data;
+		}
+
         if ( $revisionary->doing_rest && $revisionary->rest->is_posts_request && ! empty( $revisionary->rest->request ) ) {
             $postarr = array_merge( $revisionary->rest->request->get_params(), $postarr );
             
@@ -392,6 +400,10 @@ class RevisionCreation {
 			$revisionary = $this->revisionary;
 		} else {
 			global $revisionary;
+		}
+
+		if ($revisionary->disable_revision_trigger) {
+			return $data;
 		}
 
 		if ( empty( $post_arr['ID'] ) ) {
@@ -710,6 +722,8 @@ class RevisionCreation {
 				update_post_meta( $post_ID, '_wp_page_template', $postarr['page_template'] );
 			}
 		}
+
+		pp_errlog(serialize($postarr));
 	
 		// Workaround for Gutenberg stripping post thumbnail, page template on revision creation
 		foreach(['_thumbnail_id', '_wp_page_template'] as $meta_key) {

--- a/revisionary.php
+++ b/revisionary.php
@@ -5,7 +5,7 @@
  * Description: Maintain published content with teamwork and precision using the Revisions model to submit, approve and schedule changes.
  * Author: PublishPress
  * Author URI: https://publishpress.com
- * Version: 2.3.9-beta2
+ * Version: 2.3.9-beta3
  * Text Domain: revisionary
  * Domain Path: /languages/
  * Min WP Version: 4.9.7
@@ -95,7 +95,7 @@ define('REVISIONARY_FILE', __FILE__);
 // register these functions before any early exits so normal activation/deactivation can still run with RS_DEBUG
 register_activation_hook(__FILE__, function() 
 	{
-		$current_version = '2.3.9-beta2';
+		$current_version = '2.3.9-beta3';
 
 		$last_ver = get_option('revisionary_last_version');
 
@@ -170,7 +170,7 @@ add_action(
 			return;
 		}
 
-		define('REVISIONARY_VERSION', '2.3.9-beta2');
+		define('REVISIONARY_VERSION', '2.3.9-beta3');
 
 		if ( ! defined( 'RVY_VERSION' ) ) {
 			define( 'RVY_VERSION', REVISIONARY_VERSION );  // back compat

--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -21,6 +21,7 @@ class Revisionary
 	var $save_future_rev = [];
 	var $last_autosave_id = [];
 	var $last_revision = [];
+	var $disable_revision_trigger = false;
 
 	var $config_loaded = false;		// configuration related to post types and statuses must be loaded late on the init action
 	var $enabled_post_types = [];	// enabled_post_types property is set (keyed by post type slug) late on the init action. 


### PR DESCRIPTION
Scheduled revisions could not be published ahead of schedule using "Publish Now" link on preview (since 2.3.4)

Fixes #116 