### PR TITLE
Featured Image removed from revision at creation

### DIFF
--- a/revision-creation_rvy.php
+++ b/revision-creation_rvy.php
@@ -722,8 +722,6 @@ class RevisionCreation {
 				update_post_meta( $post_ID, '_wp_page_template', $postarr['page_template'] );
 			}
 		}
-
-		pp_errlog(serialize($postarr));
 	
 		// Workaround for Gutenberg stripping post thumbnail, page template on revision creation
 		foreach(['_thumbnail_id', '_wp_page_template'] as $meta_key) {

--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -138,7 +138,7 @@ class Revisionary
 		add_action('delete_post', [$this, 'actDeletePost'], 10, 3);
 
 		if (!defined('REVISIONARY_PRO_VERSION')) {
-			add_action('revisionary_saved_revision', [$this, 'act_save_revision_followup'], 5);
+			add_action('revisionary_created_revision', [$this, 'act_save_revision_followup'], 5);
 		}
 
 		add_filter('presspermit_exception_clause', [$this, 'fltPressPermitExceptionClause'], 10, 4);


### PR DESCRIPTION
This occurred in Revisions Free when a new revision was submitted without changing Featured Image.

Fixes #118