### PR TITLE
WP 5.5 - Misplaced links in Gutenberg editor sidebar

### DIFF
--- a/admin/post-edit-block-ui_rvy.php
+++ b/admin/post-edit-block-ui_rvy.php
@@ -75,6 +75,8 @@ class RVY_PostBlockEditUI {
                 $deletion_url = get_delete_post_link($post->ID, '', false);
             }
 
+            global $wp_version;
+
             $args = array(
                 'saveRevision' => __('Update Revision'),
                 'viewURL' => $view_link,
@@ -87,6 +89,7 @@ class RVY_PostBlockEditUI {
                 'deletionURL' => $can_publish ? $deletion_url : '',
                 'approvalTitle' => esc_attr(__('Approve saved changes', 'revisionary')),
                 'scheduledRevisionsEnabled' => $do_scheduled_revisions,
+                'multiPreviewActive' => version_compare($wp_version, '5.5-beta', '>=')
             );
 
         } elseif ( agp_user_can( $type_obj->cap->edit_post, $post_id, '', array( 'skip_revision_allowance' => true ) ) ) {

--- a/admin/rvy_post-block-edit.dev.js
+++ b/admin/rvy_post-block-edit.dev.js
@@ -174,6 +174,8 @@ jQuery(document).ready( function($) {
 				var pclone = $('div.edit-post-last-revision__panel a:first').clone().addClass('rvy-pending-revisions').attr('href', rvyObjEdit.pendingRevisionsURL).html(rvyObjEdit.pendingRevisionsCaption);
 				$(ediv + 'div.edit-post-last-revision__panel a:last').after(pclone);
 			}
+
+			$('div.edit-post-last-revision__panel').css('height', 'inherit');
 		}
 		var RvyPendingRevPanelInt = setInterval(RvyPendingRevPanel, 200);
 	}


### PR DESCRIPTION
Posts with pending or scheduled revisions stored had misplaced links, bad formatting in Gutenberg editor sidebar