### PR TITLE
Update class-list-table_rvy.php

### DIFF
--- a/admin/class-list-table_rvy.php
+++ b/admin/class-list-table_rvy.php
@@ -33,6 +33,10 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 			global $multiple_authors_addon;
 			remove_action('the_post', [$multiple_authors_addon, 'fix_post'], 10);
 		}
+
+		if (!empty($_REQUEST['published_post']) && !get_post_meta($post_id, '_rvy_has_revisions', true)) {
+			revisionary_refresh_postmeta($_REQUEST['published_post']);
+		}
 	}
 
 	function do_query( $q = false ) {


### PR DESCRIPTION
Pending, Scheduled revisions were not listed in Revision Queue following mirroring of posts database table from another installation (or possibly under other conditions).

This occurs when _rvy_has_revisions postmeta flag is out of sync, so refresh that flag whenever Revision Queue is accessed for a specific published post (Revision Queue link in Posts row, Revision submission confirmation, or Published Post filter link in Queue).

Fixes #155 