### PR TITLE
Add New Post: suppress revisions JS to avoid invalid editor blockage

### DIFF
--- a/admin/post-edit-block-ui_rvy.php
+++ b/admin/post-edit-block-ui_rvy.php
@@ -10,7 +10,11 @@ add_action( 'enqueue_block_editor_assets', array( 'RVY_PostBlockEditUI', 'act_ob
 
 class RVY_PostBlockEditUI {
 	public static function act_object_guten_scripts() {
-        global $current_user, $revisionary;
+        global $current_user, $revisionary, $pagenow;
+        
+        if ('post-new.php' == $pagenow) {
+            return;
+        }
         
         if ( ! $post_id = rvy_detect_post_id() ) {
             return;


### PR DESCRIPTION
Revisors and other limited editors have editor elements hidden when adding a new post, under some site configurations.

Fixes #164