### PR TITLE
Permissions Pro: redundant Pending Revision checkbox in Gutenberg

### DIFF
--- a/admin/rvy_post-block-edit.dev.js
+++ b/admin/rvy_post-block-edit.dev.js
@@ -137,12 +137,19 @@ jQuery(document).ready( function($) {
 			if ($('button.editor-post-publish-panel__toggle:visible').length && !$('div.editor-post-publish-panel:visible').length) {
 				$('#rvy_save_as_revision:visible').parent('label').hide();
 			} else {
-				var attribs = rvyObjEdit.defaultPending ? ' checked="checked"' : '';
-				if (rvyObjEdit.defaultPending) {
-					RvyRecaptionElement('button.editor-post-publish-button', rvyObjEdit.SaveCaption);
+				if (rvyObjEdit.revision && !$('#rvy_save_as_revision:visible').length) {
+					$('#rvy_save_as_revision').parent('label').remove();
+
+					var attribs = rvyObjEdit.defaultPending ? ' checked="checked"' : '';
+					
+					if (rvyObjEdit.defaultPending) {
+						RvyRecaptionElement('button.editor-post-publish-button', rvyObjEdit.SaveCaption);
+					}
+
+					$('button.editor-post-publish-button').last().after('<label style="-webkit-touch-callout: none;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;" title="' + rvyObjEdit.revisionTitle + '"><input type="checkbox" class="rvy_save_as_revision" id="rvy_save_as_revision"' + attribs + '>' + rvyObjEdit.revision + '&nbsp;</label>');
+					$('.editor-post-publish-panel__header-cancel-button').css('margin-bottom', '20px');  /* Pre-publish cancel button alignment when revision submission is enabled for unpublished posts */
 				}
-				$('button.editor-post-publish-button').after('<label style="-webkit-touch-callout: none;-webkit-user-select: none;-moz-user-select: none;-ms-user-select: none;user-select: none;" title="' + rvyObjEdit.revisionTitle + '"><input type="checkbox" class="rvy_save_as_revision" id="rvy_save_as_revision"' + attribs + '>' + rvyObjEdit.revision + '&nbsp;</label>');
-				$('.editor-post-publish-panel__header-cancel-button').css('margin-bottom', '20px');  /* Pre-publish cancel button alignment when revision submission is enabled for unpublished posts */
+
 				$('#rvy_save_as_revision').parent('label').last().show();
 			}
 		} else {


### PR DESCRIPTION
Permissions Pro: redundant Pending Revision checkbox in Gutenberg editor if Status Control module is active with Permissions Pro > 3.3.6

Fixes #188