### PR TITLE
PublishPress Permissions: Allow revision compare with Revise permissions

### DIFF
--- a/admin/history_rvy.php
+++ b/admin/history_rvy.php
@@ -279,7 +279,7 @@ class RevisionaryHistory
             return;
         }
 
-        if ( ! current_user_can( 'edit_post', $post->ID ) ) {
+        if ( ! current_user_can( 'read_post', $post->ID ) ) {
             return;
         }
 


### PR DESCRIPTION
PublishPress Permissions: Users with Revise permissions for specific pages couldn't compare Pending Revisions.

Fixes #218