### PR TITLE
lock_others_revisions setting ignored

### DIFF
--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -897,13 +897,20 @@ class Revisionary
 			$this->skip_revision_allowance = true;
 		}
 
+		$object_type_obj = get_post_type_object( $object_type );
+
 		if (rvy_get_option('revisor_lock_others_revisions')) {
-			if ($post && !rvy_is_full_editor($post)) {
+			if ($post && !rvy_is_full_editor(rvy_post_id($post->ID))) {
 				// Revisors are enabled to edit other users' posts for revision, but cannot edit other users' revisions unless cap is explicitly set sitewide
-				if ( rvy_is_revision_status($post->post_type) && ! $this->skip_revision_allowance ) {
+				if (rvy_is_revision_status($post->post_status) && !$this->skip_revision_allowance) {
 					if (!rvy_is_post_author($post)) {
 						if ( empty( $current_user->allcaps['edit_others_revisions'] ) ) {
 							$this->skip_revision_allowance = 1;
+
+							if ($object_type_obj && !empty($object_type_obj->cap->edit_others_posts)) {
+								$busy = false;
+								return array_diff_key($wp_blogcaps, [$object_type_obj->cap->edit_others_posts => true]);
+							}
 						}
 					}
 				}

--- a/rvy_init.php
+++ b/rvy_init.php
@@ -977,6 +977,10 @@ function rvy_init() {
 function rvy_is_full_editor($post, $args = []) {
 	global $current_user, $revisionary;
 	
+	if (is_numeric($post)) {
+		$post = get_post($post);
+	}
+
 	if (!$type_obj = get_post_type_object($post->post_type)) {
 		return false;
 	}


### PR DESCRIPTION
This changeset also makes function rvy_is_full_editor() accept either on WP_Post object or an integer value (post id) as the $post argument.