### PR TITLE
Compare Past Revisions: no Preview, Manage buttons for CPTs

### DIFF
--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -28,6 +28,14 @@ class Revisionary
 
 	// minimal config retrieval to support pre-init usage by WP_Scoped_User before text domain is loaded
 	function __construct() {
+		if (is_admin() && (false !== strpos($_SERVER['REQUEST_URI'], 'revision.php')) && (!empty($_REQUEST['revision']))) {
+			add_action('init', [$this, 'addFilters'], PHP_INT_MAX);
+		} else {
+			$this->addFilters();
+		}
+	}
+
+	function addFilters() {
 		global $script_name;
 
 		// Ensure editing access to past revisions is not accidentally filtered. 


### PR DESCRIPTION
When comparing past revisions of custom post types, Revisions did not insert the "Preview / Approve" and "Manage" buttons. Fixes #242 