### PR TITLE
API: Add filter to modify "Publishers to Notify" checkboxes

### DIFF
--- a/admin/revision-ui_rvy.php
+++ b/admin/revision-ui_rvy.php
@@ -86,7 +86,7 @@ function rvy_metabox_notification_list() {
 				}
 			}
 
-			$default_ids = $publisher_ids;
+			$default_ids = apply_filters('revisionary_notify_publisher_default_ids', $publisher_ids, $object_id);
 		}
 		
 		if ( '1' === $notify_author ) {
@@ -128,9 +128,10 @@ function rvy_metabox_notification_list() {
 		
 		echo("<div id='rvy_cclist_$topic'>");
 		
-		if ( $default_ids )
+		if ( $default_ids ) {
+			$post_publishers = apply_filters('revisionary_notify_publishers_eligible', $post_publishers, $object_id);
 			RevisionaryAgentsChecklist::agents_checklist( 'user', $post_publishers, $id_prefix, $default_ids );
-		else {
+		} else {
 			if ( ( 'always' === $notify_editors ) && $publisher_ids )
 				_e( 'Publishers will be notified (but cannot be selected here).', 'revisionary' );
 			else


### PR DESCRIPTION
New filters:

// boolean array with user IDs as array keys
'revisionary_notify_publisher_default_ids'

// array of WP_User objects
'revisionary_notify_publishers_eligible'

Fixes #252