### PR TITLE
WP 5.6: Pending Revision submission fails

### DIFF
--- a/admin/options.php
+++ b/admin/options.php
@@ -856,24 +856,3 @@ function rvy_options( $sitewide = false, $customize_defaults = false ) {
 	$ui = RvyOptionUI::instance(compact('sitewide', 'customize_defaults'));
 	$ui->options_ui($sitewide, $customize_defaults);
 }
-
-function rvy_is_plugin_active($check_plugin_file)
-    {
-        $plugins = (array)get_option('active_plugins');
-        foreach ($plugins as $plugin_file) {
-            if (false !== strpos($plugin_file, $check_plugin_file)) {
-                return $plugin_file;
-            }
-        }
-
-        if (is_multisite()) {
-            $plugins = (array)get_site_option('active_sitewide_plugins');
-
-            // network activated plugin names are array keys
-            foreach (array_keys($plugins) as $plugin_file) {
-                if (false !== strpos($plugin_file, $check_plugin_file)) {
-                    return $plugin_file;
-                }
-            }
-        }
-    }

--- a/rvy_init.php
+++ b/rvy_init.php
@@ -338,6 +338,26 @@ function rvy_plugin_active_for_network( $plugin ) {
 	return false;
 }
 
+function rvy_is_plugin_active($check_plugin_file) {
+	$plugins = (array)get_option('active_plugins');
+	foreach ($plugins as $plugin_file) {
+		if (false !== strpos($plugin_file, $check_plugin_file)) {
+			return $plugin_file;
+		}
+	}
+
+	if (is_multisite()) {
+		$plugins = (array)get_site_option('active_sitewide_plugins');
+
+		// network activated plugin names are array keys
+		foreach (array_keys($plugins) as $plugin_file) {
+			if (false !== strpos($plugin_file, $check_plugin_file)) {
+				return $plugin_file;
+			}
+		}
+	}
+}
+
 function rvy_configuration_late_init() {
 	global $revisionary;
 
@@ -1206,7 +1226,7 @@ function my_post_types_config() {
 	}
 
 	$rest_cache_active = $rest_cache_active 
-	|| ((!empty($_REQUEST['wp-remove-post-lock']) || strpos($uri, '_locale')) && is_plugin_active('wp-rest-cache/wp-rest-cache.php'));
+	|| ((!empty($_REQUEST['wp-remove-post-lock']) || strpos($uri, '_locale')) && rvy_is_plugin_active('wp-rest-cache/wp-rest-cache.php'));
 
 	if ($rest_cache_active) {
 		foreach(array_keys($wp_post_types) as $key) {


### PR DESCRIPTION
Pending Revision submission from the Gutenberg editor failed because WP function is_plugin_active() does not exist at REST query handling.

Fixes #287