### PR TITLE
Non-public post types display ineffective preview link

### DIFF
--- a/admin/PostEditSubmitMetabox.php
+++ b/admin/PostEditSubmitMetabox.php
@@ -173,7 +173,10 @@ class RvyPostEditSubmitMetabox
 
                 $type_obj = get_post_type_object($post->post_type);
                 $can_publish = $type_obj && agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
-                if ($can_publish) {
+                
+                if ($type_obj && empty($type_obj->public)) {
+                    return;
+                } elseif ($can_publish) {
                     $preview_button = ('future-revision' == $post->post_status) ? __('View / Publish', 'revisionary') : __('View / Approve', 'revisionary');
                     $preview_title = __('View / moderate saved revision', 'revisionary');
                 } else {

--- a/admin/class-list-table_rvy.php
+++ b/admin/class-list-table_rvy.php
@@ -1122,7 +1122,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 		}
 
 		if ( is_post_type_viewable( $post_type_object ) ) {
-			if ( $can_read_post ) {
+			if ($can_read_post && $post_type_object && !empty($post_type_object->public)) {
 				if (rvy_get_option('revision_preview_links') || current_user_can('administrator') || is_super_admin()) {
 					$preview_link = rvy_preview_url($post);
 

--- a/admin/history_rvy.php
+++ b/admin/history_rvy.php
@@ -877,7 +877,8 @@ class RevisionaryHistory
                 if ($can_restore) {
                     $published_post_id = rvy_post_id($revision->ID);
 
-	                if (rvy_get_option('compare_revisions_direct_approval') && agp_user_can( 'edit_post', $published_post_id, '', ['skip_revision_allowance' => true] ) ) {
+                    // For non-public types, force direct approval because preview is not available
+	                if ((($type_obj && empty($type_obj->public)) || rvy_get_option('compare_revisions_direct_approval')) && agp_user_can( 'edit_post', $published_post_id, '', ['skip_revision_allowance' => true] ) ) {
                         $redirect_arg = ( ! empty($_REQUEST['rvy_redirect']) ) ? "&rvy_redirect=" . esc_url($_REQUEST['rvy_redirect']) : '';
 
                         if (in_array($revision->post_status, ['pending-revision'])) {
@@ -1044,7 +1045,9 @@ class RevisionaryHistory
             $type_obj = get_post_type_object($post_type);
         }
 
-        $direct_approval = rvy_get_option('compare_revisions_direct_approval') && agp_user_can( 'edit_post', rvy_post_id($post_id), '', ['skip_revision_allowance' => true] );
+        // For non-public types, force direct approval because preview is not available
+        $direct_approval = (($type_obj && empty($type_obj->public)) || rvy_get_option('compare_revisions_direct_approval')) 
+        && agp_user_can('edit_post', rvy_post_id($post_id), '', ['skip_revision_allowance' => true]);
 
         if ($post_id) {
             $can_approve = agp_user_can('edit_post', rvy_post_id($post_id), 0, ['skip_revision_allowance' => true]);

--- a/admin/post-edit-block-ui_rvy.php
+++ b/admin/post-edit-block-ui_rvy.php
@@ -42,8 +42,13 @@ class RVY_PostBlockEditUI {
 
             if (rvy_get_option('revision_preview_links') || current_user_can('administrator') || is_super_admin()) {
                 $view_link = rvy_preview_url($post);
+                $can_publish = agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
 
-                if ($can_publish = agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true))) {
+                if ($type_obj && empty($type_obj->public)) {
+                    $view_link = '';
+                    $view_caption = '';
+                    $view_title = '';
+                } elseif ($can_publish) {
                     $view_caption = ('future-revision' == $post->post_status) ? __('View / Publish', 'revisionary') : __('View / Approve', 'revisionary');
                     $view_title = __('View / moderate saved revision', 'revisionary');
                 } else {
@@ -173,6 +178,7 @@ class RVY_PostBlockEditUI {
                 'prePublish' => __( 'Workflow&hellip;', 'revisionary' ),
                 'redirectURL' => admin_url("edit.php?post_type={$post_type}&revision_submitted={$status}&post_id={$post_id}"),
                 'revisableStatuses' => rvy_filtered_statuses('names'),
+                'editRevisionURL' => $editRevisionURL,
             );
 
             if (defined('REVISIONARY_DISABLE_SUBMISSION_REDIRECT') || !apply_filters('revisionary_do_submission_redirect', true)) {

--- a/admin/post-edit_rvy.php
+++ b/admin/post-edit_rvy.php
@@ -92,7 +92,13 @@ class RvyPostEdit {
 
             $view_link = rvy_preview_url($post);
 
-            if ($can_publish = agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true))) {
+            $can_publish = agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
+
+            if ($type_obj && empty($type_obj->public)) {
+                $view_link = '';
+                $view_caption = '';
+                $view_title = '';
+            } elseif ($can_publish) {
                 $view_caption = ('future-revision' == $post->post_status) ? __('View / Publish', 'revisionary') : __('View / Approve', 'revisionary');
                 $view_title = __('View / moderate saved revision', 'revisionary');
             } else {
@@ -237,7 +243,11 @@ class RvyPostEdit {
             	$url = add_query_arg('_thumbnail_id', $revisionary->last_autosave_id[$_post->ID], $url);
             }
         } elseif ($post && rvy_is_revision_status($post->post_status)) {
-            $url = rvy_preview_url($post);
+            $type_obj = get_post_type_object($post->post_type);
+
+            if ($type_obj && !empty($type_obj->public)) {
+            	$url = rvy_preview_url($post);
+        	}
         }
 
         return $url;
@@ -247,10 +257,15 @@ class RvyPostEdit {
         global $post;
 
         $type_obj = get_post_type_object($post->post_type);
+
+        if ($type_obj && empty($type_obj->public)) {
+            return $preview_caption;
+        }
+
         $can_publish = $type_obj && agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
         if ($can_publish) {
             $preview_caption = ('future-revision' == $post->post_status) ? __('View / Publish', 'revisionary') : __('View / Approve', 'revisionary');
-        } else {
+        } elseif ($type_obj && !empty($type_obj->public)) {
             $preview_caption = __('View');
         }
 
@@ -261,10 +276,15 @@ class RvyPostEdit {
         global $post;
 
         $type_obj = get_post_type_object($post->post_type);
+
+        if ($type_obj && empty($type_obj->public)) {
+            return $preview_title;
+        }
+
         $can_publish = $type_obj && agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
         if ($can_publish) {
             $preview_title = __('View / moderate saved revision', 'revisionary');
-        } else {
+        } elseif ($type_obj && !empty($type_obj->public)) {
             $preview_title = __('View saved revision', 'revisionary');
         }
 

--- a/revision-workflow_rvy.php
+++ b/revision-workflow_rvy.php
@@ -240,7 +240,9 @@ class Rvy_Revision_Workflow_UI {
                 
                 $msg .= '<ul>';
 
-                if (rvy_get_option('revision_preview_links') || current_user_can('administrator') || is_super_admin()) {
+                $type_obj = get_post_type_object($revision->post_type);
+
+                if (($type_obj && !empty($type_obj->public)) && (rvy_get_option('revision_preview_links') || current_user_can('administrator') || is_super_admin())) {
                     $preview_link = rvy_preview_url($revision);
                     $preview_link = remove_query_arg('preview_id', $preview_link);
 

--- a/rvy_init.php
+++ b/rvy_init.php
@@ -1154,6 +1154,12 @@ function rvy_preview_url($revision, $args = []) {
 		$$var = (!empty($args[$var])) ? $args[$var] : $defaults[$var]; 
 	}
 
+	if ($post_type_obj = get_post_type_object($revision->post_type)) {
+		if (empty($post_type_obj->public)) { // For non-public types, preview is not available so default to Compare Revisions screen
+			return apply_filters('revisionary_preview_url', admin_url("revision.php?revision=$revision->ID"), $revision, $args);
+		}
+	}
+
 	$link_type = rvy_get_option('preview_link_type');
 
 	$status_obj = get_post_status_object(get_post_field('post_status', rvy_post_id($revision->ID)));


### PR DESCRIPTION
If the 'revisionary_supported_post_types' filter is used to enable revisions for a non-public post type, that post type has ineffective revision preview links.

Suppress the link where appropriate and default rvy_preview_url() output to Compare Revisions screen as a fallback.

Fixes #309