### PR TITLE
Restore previous REST API Cache compat provision, with modifications

### DIFF
--- a/rvy_init.php
+++ b/rvy_init.php
@@ -1220,6 +1220,34 @@ function rvy_filtered_statuses($output = 'names') {
 }
 
 // REST API Cache plugin compat
+add_action('init', 'rvy_rest_cache_compat', 9999);
+
+function rvy_rest_cache_compat() {
+	global $wp_post_types;
+
+	$uri = $_SERVER['REQUEST_URI'];
+
+	$rest_cache_active = false;
+	foreach(['rvy_ajax_field', 'rvy_ajax_value', 'revision_submitted'] as $param) {
+		if (strpos($uri, $param)) {
+			$rest_cache_active = true;
+			break;
+		}
+	}
+
+	/*
+	$rest_cache_active = $rest_cache_active 
+	|| ((!empty($_REQUEST['wp-remove-post-lock']) || strpos($uri, '_locale')) && rvy_is_plugin_active('wp-rest-cache/wp-rest-cache.php'));
+	*/
+
+	if ($rest_cache_active) {
+		foreach(array_keys($wp_post_types) as $key) {
+			$wp_post_types[$key]->rest_controller_class = ('attachment' == $key) ? 'WP_REST_Attachments_Controller' : 'WP_REST_Posts_Controller';
+		}
+	}
+}
+
+// REST API Cache plugin compat
 add_filter('wp_rest_cache/skip_caching', 'rvy_rest_cache_skip');
 
 function rvy_rest_cache_skip($skip) {


### PR DESCRIPTION
Restore previous 'init' filter which sets rest_controller_class to defaults, but narrow conditions for this workaround to apply only to Revisions queries.  Also correct implementation to default to WP_REST_Attachments_Controller for post_type 'attachment'