### PR TITLE
Classic Editor: No link to Compare Revisions screen for past revisions

### DIFF
--- a/admin/filters-admin-ui-item_rvy.php
+++ b/admin/filters-admin-ui-item_rvy.php
@@ -151,7 +151,7 @@ jQuery(document).ready( function($) {
 	);
 	*/
 
-	if (!$revisionary->canEditPost($post, ['simple_cap_check' => true])):?>
+	if (!$revisionary->canEditPost($post, ['simple_cap_check' => true]) && defined('RVY_REVISOR_SUPPRESS_REVISIONS_LINK')):?>
 	<style>
 	div.num-revisions, div.misc-pub-revisions {display:none;}
 	</style>


### PR DESCRIPTION
The Revisions link was disabled due to Compare Revisions issues that are now addressed by other commits.