### PR TITLE
Revisors can't preview other users' pending revisions, even if listed in Revision Queue

### DIFF
--- a/front_rvy.php
+++ b/front_rvy.php
@@ -186,7 +186,7 @@ class RevisionaryFront {
 			$published_url = ($published_post_id) ? get_permalink($published_post_id) : '';
 			$diff_url = admin_url("revision.php?revision=$revision_id");
 			
-			if (current_user_can( 'read_post', $revision_id)) { 
+			if ((!rvy_get_option('revisor_hide_others_revisions') && !empty($type_obj) && current_user_can($type_obj->cap->edit_posts)) || current_user_can('read_post', $revision_id)) { 
 				$view_published = ($published_url) 
 				? sprintf(
 					apply_filters(


### PR DESCRIPTION
Note: Permissions integration requires 3.5.1