### PR TITLE
Release 2.5.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -19,29 +19,42 @@ WordPress Revisions are a powerful way to track where your site has been. But wh
 
 To moderate or schedule changes to published posts, just install PublishPress Revisions and let the teamwork begin. There is no need to learn or configure complex new screens because PublishPress Revisions works with familiar WordPress UI, including the Gutenberg and the Classic Editor.
 
-= Submit Revisions =
+The Free version of PublishPress Revisions supports the WordPress core. The Pro version of PublishPress Revisions supports ACF, Yoast SEO, PODS, WooCommerce, WPML, Elementor, Beaver Builder, and many more plugins and themes.
+
+= Submit Change Requests for Posts =
 PublishPress Revisions allows your users to submit change requests for published posts. Your users can update posts using the normal WordPress editor, but their changes will not be published automatically. Instead, the changes are stored as a "pending revision" that can be approved or rejected.
 [Click here to see how to submit revisions](https://publishpress.com/knowledge-base/revisions-start/).
 
-= Schedule Revisions =
+= Schedule Future Updates to Posts =
 PublishPress Revisions allows you to schedule WordPress revisions to be published in the future. When you're editing a published post, all you need to do is select a future date and click "Schedule Revision". Your changes will be published at the specified time.
 [Click here to see how to schedule revisions](https://publishpress.com/knowledge-base/schedule-revisions-future/).
 
-= Manage and Moderate Revisions =
+= Manage and Moderate Changes to Content =
 After you create a revision with PublishPress Revisions, you can find that revision on the Revision Queue screen. This screen shows you all the revisions that have been submitted for approval. Underneath each revision you can choose from several moderation tools: Edit, Delete, Preview and Compare.
 [Click here to see how to manage and moderate revisions](https://publishpress.com/knowledge-base/schedule-or-publish-revisions/).
 
-= Compare Revisions =
+= Compare Current and Former Versions =
 Pending and Scheduled Revisions can include changes to post content, categories, tags, featured image, page parent and other options. Each of these changes can be reviewed in the familiar Compare Revisions interface.
 [Click here to see how to compare revisions](https://publishpress.com/knowledge-base/compare-revisions/).
 
-= Frontend Moderation of Revisions =
+= Frontend Moderation of Changes =
 It is possible to preview and moderate revisions via the frontend of your WordPress site. If you click Preview for a pending revision, you'll see a toolbar across the frontend of the site. This toolbar will change color so you can easily know the status of the revision. For example, if you're looking at a pending revision, the toolbar will be green. For scheduled revisions, the toolbar will be grey.
 [Click here to see how to manage from the frontend of your site](https://publishpress.com/knowledge-base/publishing-revisions-frontend/).
 
 = Email Notifications for Revisions =
 PublishPress Revisions will notify Administrators and Editors when a new revision is submitted. They can log in to preview, compare and approve the changes. PublishPress Revisions can also send emails for revision approval and publication. The Settings screen lets you disable unwanted notifications.
 [Click here for more on revision notifications](https://publishpress.com/knowledge-base/emails-revisionary/).
+
+= Additional Supported Plugins in the Pro Version =
+* Advanced Custom Fields integration
+* BeaverBuilder integration (front end revision submission)
+* WPML integration (revision queue follows language filter)
+* Pods compatibility
+* The Events Calendar compatibility
+* WooCommerce compatibility
+* Yoast SEO compatibility
+
+[Click here for the full list of supported plugins in the Pro version](https://publishpress.com/knowledge-base/plugins-revisions-support/).
 
 = Revision Permissions =
 PublishPress Revisions works with the default WordPress user roles, and also introduces a Revisor role:
@@ -54,15 +67,6 @@ To schedule changes to a published post, just set the desired future date before
 
 By upgrading to Revisions Pro, you also gain advanced permissions control through the PublishPress Permissions Pro plugin. You can customize permissions by role or per-user, granting full editing or revision submission rights to specific posts, categories, or taxonomy terms.
 [Click here for more on revision permissions](https://publishpress.com/knowledge-base/permissions-revisions).
-
-= Additional Features in the Pro Version =
-* Advanced Custom Fields integration
-* BeaverBuilder integration (front end revision submission)
-* WPML integration (revision queue follows language filter)
-* Pods compatibility
-* The Events Calendar compatibility
-* WooCommerce compatibility
-* Yoast SEO compatibility
 
 = Join PublishPress and get the Pro plugins =
 * [PublishPress Authors Pro](https://publishpress.com/authors) allows you to add multiple authors and guest authors to WordPress posts.

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags: revision, submit changes, workflow, collaboration, permissions, moderate, 
 Requires at least: 4.9.7
 Requires PHP: 5.6.20
 Tested up to: 5.7
-Stable tag: 2.5.1
+Stable tag: 2.5.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -103,6 +103,9 @@ Follow PublishPress on [Facebook](https://www.facebook.com/publishpress), [Twitt
 12. Scheduled Revisions in Publishing Soon list
 
 == Changelog ==
+
+= 2.5.2 - 30 Mar 2021 =
+* Fixed : Fatal error due to incorrect vendor library load request
 
 = 2.5.1 - 30 Mar 2021 =
 * Fixed : Revisors could not preview other users' pending revisions, even if they are listed in Revision Queue (Permissions integration requires 3.5.1)

--- a/revisionary.php
+++ b/revisionary.php
@@ -5,7 +5,7 @@
  * Description: Maintain published content with teamwork and precision using the Revisions model to submit, approve and schedule changes.
  * Author: PublishPress
  * Author URI: https://publishpress.com
- * Version: 2.5.1
+ * Version: 2.5.2
  * Text Domain: revisionary
  * Domain Path: /languages/
  * Min WP Version: 4.9.7
@@ -96,7 +96,7 @@ define('REVISIONARY_FILE', __FILE__);
 // register these functions before any early exits so normal activation/deactivation can still run with RS_DEBUG
 register_activation_hook(__FILE__, function() 
 	{
-		$current_version = '2.5.1';
+		$current_version = '2.5.2';
 
 		$last_ver = get_option('revisionary_last_version');
 
@@ -172,7 +172,7 @@ add_action(
 			return;
 		}
 
-		define('REVISIONARY_VERSION', '2.5.1');
+		define('REVISIONARY_VERSION', '2.5.2');
 
 		if ( ! defined( 'RVY_VERSION' ) ) {
 			define( 'RVY_VERSION', REVISIONARY_VERSION );  // back compat


### PR DESCRIPTION
This is an accounting consistency release to correspond to wordpress.org. The version 2.5.1 release to the WP svn included incorrect vendor library code (erroneously copied from Revisions Pro).