### PR TITLE
Fatal Error in plugin editor (on some installations)

### DIFF
--- a/rvy_init.php
+++ b/rvy_init.php
@@ -356,7 +356,7 @@ function rvy_status_registrations() {
 	));
 
 	foreach(rvy_get_manageable_types() as $post_type) {
-		add_filter("rest_{$post_type}_collection_params", function($query_params, $post_type) 
+		add_filter("rest_{$post_type}_collection_params", function($query_params, $post_type = '') 
 			{
 				$query_params['status']['items']['enum'] []= 'pending-revision';
 				$query_params['status']['items']['enum'] []= 'future-revision';


### PR DESCRIPTION
Fixes #410

On some sites, the filter "rest_{$post_type}_collection_params" is applied with a single argument.