### PR TITLE
When checking user's capabilities, pass 'edit_post' not $cap->edit_post

### DIFF
--- a/admin/PostEditSubmitMetabox.php
+++ b/admin/PostEditSubmitMetabox.php
@@ -172,7 +172,8 @@ class RvyPostEditSubmitMetabox
                 $preview_link = rvy_preview_url($post);
 
                 $type_obj = get_post_type_object($post->post_type);
-                $can_publish = $type_obj && agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
+
+                $can_publish = agp_user_can('edit_post', rvy_post_id($post->ID), '', ['skip_revision_allowance' => true]);
                 
                 if ($type_obj && empty($type_obj->public)) {
                     return;

--- a/admin/admin-init_rvy.php
+++ b/admin/admin-init_rvy.php
@@ -111,7 +111,7 @@ function rvy_admin_init() {
 					}
 					
 					if ( !$is_administrator 
-					&& !agp_user_can($type_obj->cap->edit_post, rvy_post_id($revision->ID), '', ['skip_revision_allowance' => true])
+					&& !agp_user_can('edit_post', rvy_post_id($revision->ID), '', ['skip_revision_allowance' => true])
 					) {
 						if (count($post_ids) == 1) {
 							wp_die( __('Sorry, you are not allowed to approve this revision.', 'revisionary') );
@@ -154,7 +154,7 @@ function rvy_admin_init() {
 					}
 					
 					if ( !$is_administrator 
-					&& !agp_user_can($type_obj->cap->edit_post, rvy_post_id($revision->ID), '', ['skip_revision_allowance' => true])
+					&& !agp_user_can('edit_post', rvy_post_id($revision->ID), '', ['skip_revision_allowance' => true])
 					) {
 						if (count($post_ids) == 1) {
 							wp_die( __('Sorry, you are not allowed to approve this revision.', 'revisionary') );

--- a/admin/admin_rvy.php
+++ b/admin/admin_rvy.php
@@ -469,8 +469,7 @@ class RevisionaryAdmin
 			if ( $post && rvy_is_supported_post_type($post->post_type)) {
 				if ( $revisionary->isBlockEditorActive() ) {
 					if ( ! $post->ID && ! is_content_administrator_rvy() ) {
-						$type_obj = get_post_type_object( $post->post_type );
-						if ( $type_obj && ! agp_user_can( $type_obj->cap->edit_post, $post->ID, '', array( 'skip_revision_allowance' => true ) ) ) {
+						if (!agp_user_can('edit_post', $post->ID, '', ['skip_revision_allowance' => true])) {
 							wp_deregister_script( 'autosave' );
 							wp_dequeue_script( 'autosave' );
 						}
@@ -544,10 +543,8 @@ class RevisionaryAdmin
 			return;
 		}
 
-		if ( $type_obj = get_post_type_object( $post->post_type ) ) {
-			if ( ! agp_user_can( $type_obj->cap->edit_post, $post->ID, '', array( 'skip_revision_allowance' => true ) ) ) {
-				return;
-			}
+		if (!agp_user_can('edit_post', $post->ID, '', ['skip_revision_allowance' => true])) {
+			return;
 		}
 
 		$caption = apply_filters('revisionary_pending_checkbox_caption_classic', __( 'Save as Pending Revision', 'revisionary' ), $post);
@@ -787,9 +784,7 @@ class RevisionaryAdmin
 			$object_id = rvy_detect_post_id();
 
 			if ( $object_id ) {
-				$type_obj = get_post_type_object( $object_type );
-
-				if ( $type_obj && !empty($post) && (rvy_is_revision_status($post->post_status) || ! agp_user_can( $type_obj->cap->edit_post, $object_id, '', array( 'skip_revision_allowance' => true ) ) ) ) { 
+				if (!empty($post) && (rvy_is_revision_status($post->post_status) || !agp_user_can('edit_post', $object_id, '', ['skip_revision_allowance' => true]))) { 
 					//if ( 'page' == $object_type )
 						//$unrevisable_css_ids = array( 'pageauthordiv', 'pagecustomdiv', 'pageslugdiv', 'pagecommentstatusdiv' );
 				 	//else

--- a/admin/filters-admin-ui-item_rvy.php
+++ b/admin/filters-admin-ui-item_rvy.php
@@ -24,8 +24,7 @@ class RevisionaryAdminFiltersItemUI {
 
 			$object_id = rvy_detect_post_id();
 			
-			if ( $type_obj = get_post_type_object( $object_type ) ) {
-				if ( ! $object_id || agp_user_can( $type_obj->cap->edit_post, $object_id, '', array( 'skip_revision_allowance' => true ) ) ) {
+			if (!$object_id || agp_user_can('edit_post', $object_id, '', ['skip_revision_allowance' => true])) {
 					// for logged user who can fully edit a published post, clarify the meaning of setting future publish date
 					
 					// @todo: pass post id value, admin URL into JS to support ajax call
@@ -101,7 +100,6 @@ class RevisionaryAdminFiltersItemUI {
 					return;
 				}
 			}
-		}
 
 		wp_deregister_script( 'autosave' );
 		wp_dequeue_script( 'autosave' );
@@ -220,8 +218,7 @@ jQuery(document).ready( function($) {
 							
 					// Remove Revision Notification List metabox if this user is NOT submitting a pending revision
 					} elseif ( 'pending_revision_notify' == $box_id ) {
-						if ( $type_obj = get_post_type_object( $object_type ) ) {
-							if ( ! $object_id || ! rvy_get_option('pending_rev_notify_admin') || agp_user_can( $type_obj->cap->edit_post, $object_id, '', array( 'skip_revision_allowance' => true ) ) )
+						if (!$object_id || !rvy_get_option('pending_rev_notify_admin') || agp_user_can('edit_post', $object_id, '', ['skip_revision_allowance' => true])) {
 								unset( $wp_meta_boxes[$object_type][$context][$priority][$box_id] );
 						}
 					}

--- a/admin/history_rvy.php
+++ b/admin/history_rvy.php
@@ -859,7 +859,7 @@ class RevisionaryHistory
 
         $type_obj = get_post_type_object($post->post_type);
         
-        $can_restore = agp_user_can( $type_obj->cap->edit_post, $post->ID, '', ['skip_revision_allowance' => true] );
+        $can_restore = agp_user_can('edit_post', $post->ID, '', ['skip_revision_allowance' => true]);
 
         $current_id  = false;
 

--- a/admin/post-edit-block-ui_rvy.php
+++ b/admin/post-edit-block-ui_rvy.php
@@ -68,7 +68,7 @@ class RVY_PostBlockEditUI {
 
             if (rvy_get_option('revision_preview_links') || current_user_can('administrator') || is_super_admin()) {
                 $view_link = rvy_preview_url($post);
-                $can_publish = agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
+                $can_publish = agp_user_can('edit_post', rvy_post_id($post->ID), '', ['skip_revision_allowance' => true]);
 
                 if ($type_obj && empty($type_obj->public)) {
                     $view_link = '';
@@ -132,7 +132,7 @@ class RVY_PostBlockEditUI {
                 unset($args['redirectURLupdate']);
             }
 
-        } elseif ( agp_user_can( $type_obj->cap->edit_post, $post_id, '', array( 'skip_revision_allowance' => true ) ) ) {
+        } elseif (agp_user_can('edit_post', $post_id, '', ['skip_revision_allowance' => true])) {
             wp_enqueue_script( 'rvy_object_edit', RVY_URLPATH . "/admin/rvy_post-block-edit{$suffix}.js", array('jquery', 'jquery-form'), RVY_VERSION, true );
 
             $args = array();

--- a/admin/post-edit_rvy.php
+++ b/admin/post-edit_rvy.php
@@ -110,7 +110,7 @@ class RvyPostEdit {
 
             $view_link = rvy_preview_url($post);
 
-            $can_publish = agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
+            $can_publish = agp_user_can('edit_post', rvy_post_id($post->ID), '', ['skip_revision_allowance' => true]);
 
             if ($type_obj && empty($type_obj->public)) {
                 $view_link = '';
@@ -220,7 +220,7 @@ class RvyPostEdit {
             return;
         }
 
-        $can_publish = agp_user_can( $type_obj->cap->edit_post, rvy_post_id($post->ID), '', array( 'skip_revision_allowance' => true ) );
+        $can_publish = agp_user_can('edit_post', rvy_post_id($post->ID), '', ['skip_revision_allowance' => true]);
 
         if ($can_publish && rvy_is_revision_status($post->post_status)):?>
             <?php
@@ -280,7 +280,8 @@ class RvyPostEdit {
             return $preview_caption;
         }
 
-        $can_publish = $type_obj && agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
+        $can_publish = agp_user_can('edit_post', rvy_post_id($post->ID), '', ['skip_revision_allowance' => true]);
+        
         if ($can_publish) {
             $preview_caption = ('future-revision' == $post->post_status) ? __('View / Publish', 'revisionary') : __('View / Approve', 'revisionary');
         } elseif ($type_obj && !empty($type_obj->public)) {
@@ -299,7 +300,8 @@ class RvyPostEdit {
             return $preview_title;
         }
 
-        $can_publish = $type_obj && agp_user_can($type_obj->cap->edit_post, rvy_post_id($post->ID), '', array('skip_revision_allowance' => true));
+        $can_publish = agp_user_can('edit_post', rvy_post_id($post->ID), '', ['skip_revision_allowance' => true]);
+        
         if ($can_publish) {
             $preview_title = __('View / moderate saved revision', 'revisionary');
         } elseif ($type_obj && !empty($type_obj->public)) {
@@ -335,7 +337,7 @@ class RvyPostEdit {
             return;
         }
 
-		if ( $type_obj && ! agp_user_can( $type_obj->cap->edit_post, $post->ID, '', array( 'skip_revision_allowance' => true ) ) ) {
+        if (!agp_user_can('edit_post', $post->ID, '', ['skip_revision_allowance' => true])) {
             return;
         }
 

--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -51,9 +51,8 @@ function rvy_revision_approve($revision_id = 0) {
 			break;
 		}
 
-		if ( $type_obj = get_post_type_object( $post->post_type ) ) {
-			if ( ! agp_user_can( $type_obj->cap->edit_post, $post->ID, '', array( 'skip_revision_allowance' => true ) ) )
-				break;
+		if (!agp_user_can('edit_post', $post->ID, '', ['skip_revision_allowance' => true])) {
+			break;
 		}
 
 		if (!$batch_process) {
@@ -323,9 +322,8 @@ function rvy_revision_restore() {
 		if ( !$post = get_post( $revision->post_parent ) )
 			break;
 
-		if ( $type_obj = get_post_type_object( $post->post_type ) ) {
-			if ( ! agp_user_can( $type_obj->cap->edit_post, $revision->post_parent, '', array( 'skip_revision_allowance' => true ) ) )
-				break;
+		if (!agp_user_can('edit_post', $revision->post_parent, '', ['skip_revision_allowance' => true])) {
+			break;
 		}
 
 		check_admin_referer( "restore-post_{$post->ID}|$revision->ID" );
@@ -847,10 +845,8 @@ function rvy_revision_unschedule($revision_id) {
 			break;
 		}
 
-		if ( $type_obj = get_post_type_object( $revision->post_type ) ) {
-			if ( ! agp_user_can( $type_obj->cap->edit_post, $published_id, '', array( 'skip_revision_allowance' => true ) ) ) {
-				break;
-			}
+		if (!agp_user_can('edit_post', $published_id, '', ['skip_revision_allowance' => true])) {
+			break;
 		}
 
 		$wpdb->update( $wpdb->posts, array( 'post_status' => 'pending-revision' ), array( 'ID' => $revision->ID ) );
@@ -887,9 +883,8 @@ function rvy_revision_publish($revision_id = false) {
 			break;
 		}
 
-		if ( $type_obj = get_post_type_object( $post->post_type ) ) {
-			if ( ! agp_user_can( $type_obj->cap->edit_post, $post->ID, '', array( 'skip_revision_allowance' => true ) ) )
-				break;
+		if (!agp_user_can('edit_post', $post->ID, '', ['skip_revision_allowance' => true])) {
+			break;
 		}
 
 		if (!$batch_process) {
@@ -1109,15 +1104,17 @@ function rvy_publish_scheduled_revisions($args = array()) {
 							$revisionary->content_roles->ensure_init();
 	
 							if ( $default_ids = $revisionary->content_roles->get_metagroup_members( 'Scheduled Revision Monitors' ) ) {
-								if ( $type_obj = get_post_type_object( $object_type ) ) {
-									$revisionary->skip_revision_allowance = true;
-									$cols = ( defined('COLS_ALL_RS') ) ? COLS_ALL_RS : 'all';
-									$post_publishers = $revisionary->content_roles->users_who_can( $type_obj->cap->edit_post, $object_id, array( 'cols' => $cols ) );
-									$revisionary->skip_revision_allowance = false;
-									
-									foreach ( $post_publishers as $user )
-										if ( in_array( $user->ID, $default_ids ) )
-											$to_addresses []= $user->user_email;
+								$revisionary->skip_revision_allowance = true;
+								$cols = ( defined('COLS_ALL_RS') ) ? COLS_ALL_RS : 'all';
+
+								$post_publishers = $revisionary->content_roles->users_who_can('edit_post', $object_id, array( 'cols' => $cols ) );
+
+								$revisionary->skip_revision_allowance = false;
+								
+								foreach ($post_publishers as $user) {
+									if (in_array($user->ID, $default_ids)) {
+										$to_addresses []= $user->user_email;
+									}
 								}
 							}
 						} 

--- a/admin/revision-ui_rvy.php
+++ b/admin/revision-ui_rvy.php
@@ -212,9 +212,7 @@ function rvy_list_post_revisions( $post_id = 0, $status = '', $args = null ) {
 	$rows = '';
 	$class = false;
 	
-	$type_obj = get_post_type_object( $post->post_type );
-	
-	$can_edit_post = agp_user_can( $type_obj->cap->edit_post, $post->ID, '', array( 'skip_revision_allowance' => true ) );
+	$can_edit_post = agp_user_can('edit_post', $post->ID, '', ['skip_revision_allowance' => true]);
 	
 	$hide_others_revisions = ! $can_edit_post && empty($current_user->allcaps['list_others_revisions']) && rvy_get_option('revisor_hide_others_revisions');
 	

--- a/admin/revisions.php
+++ b/admin/revisions.php
@@ -115,7 +115,7 @@ default :
 	}
 
 	if ( $type_obj = get_post_type_object( $rvy_post->post_type ) ) {
-		$edit_cap = $type_obj->cap->edit_post;
+		$edit_cap = 'edit_post';
 		$edit_others_cap = $type_obj->cap->edit_others_posts;
 		$delete_cap = $type_obj->cap->delete_post;
 	}

--- a/front_rvy.php
+++ b/front_rvy.php
@@ -177,14 +177,12 @@ class RevisionaryFront {
 			$message = '';
 
 			// This topbar is presently only for those with restore / approve / publish rights
-			if ( $type_obj = get_post_type_object( $post->post_type ) ) {
-				$cap_name = $type_obj->cap->edit_post;	
-			}
+			$type_obj = get_post_type_object( $post->post_type );
 
 			$orig_skip = ! empty( $revisionary->skip_revision_allowance );
 			$revisionary->skip_revision_allowance = true;
 
-			$can_publish = agp_user_can( $cap_name, $published_post_id, '', array( 'skip_revision_allowance' => true ) );
+			$can_publish = agp_user_can('edit_post', $published_post_id, '', ['skip_revision_allowance' => true]);
 
 			$redirect_arg = ( ! empty($_REQUEST['rvy_redirect']) ) ? "&rvy_redirect=" . esc_url($_REQUEST['rvy_redirect']) : '';
 

--- a/rest_rvy.php
+++ b/rest_rvy.php
@@ -21,7 +21,7 @@ class Revisionary_REST {
 			
 			if ( $type_obj = get_post_type_object( $post_type ) ) {
 				if ( $orig_cap == $type_obj->cap->read_post ) {
-					$orig_cap = $type_obj->cap->edit_post;
+					$orig_cap = 'edit_post';
 				}
 			}
 		}

--- a/revision-creation_rvy.php
+++ b/revision-creation_rvy.php
@@ -121,10 +121,8 @@ class RevisionCreation {
 				return $status;
 			}
 
-			if ( $type_obj = get_post_type_object( $post_type ) ) {
-				if ( ! agp_user_can( $type_obj->cap->edit_post, $post_id, '', array( 'skip_revision_allowance' => true ) ) ) {
-					$revisionary->impose_pending_rev[$post_id] = true;
-				}
+			if (!agp_user_can('edit_post', $post_id, '', ['skip_revision_allowance' => true])) {
+				$revisionary->impose_pending_rev[$post_id] = true;
 			}
 		}
 		
@@ -559,10 +557,8 @@ class RevisionCreation {
 			}
 		}
 
-		if ( $type_obj = get_post_type_object( $published_post->post_type ) ) {
-			if ( ! agp_user_can( $type_obj->cap->edit_post, $published_post->ID, $current_user->ID, array( 'skip_revision_allowance' => true ) ) ) {
-				return $data;
-			}
+		if (!agp_user_can('edit_post', $published_post->ID, $current_user->ID, ['skip_revision_allowance' => true])) {
+			return $data;
 		}
 		
 		// @todo: need to filter post parent?

--- a/revision-workflow_rvy.php
+++ b/revision-workflow_rvy.php
@@ -62,8 +62,8 @@ class Rvy_Revision_Workflow_UI {
                 }
                 
                 foreach ( $recipients as $_user ) {	
-                    $reqd_caps = map_meta_cap( $type_obj->cap->edit_post, $_user->ID, $object_id );
-    
+                    $reqd_caps = map_meta_cap( 'edit_post', $_user->ID, $object_id );
+
                     if ( ! array_diff( $reqd_caps, array_keys( array_intersect( $_user->allcaps, array( true, 1, '1' ) ) ) ) ) {
                         $post_publishers []= $_user;
                         $publisher_ids [$_user->ID] = true;
@@ -96,7 +96,7 @@ class Rvy_Revision_Workflow_UI {
                         $revisionary->skip_revision_allowance = false;
                     } else {
                         $_user = new WP_User($author_id);
-                        $reqd_caps = map_meta_cap( $type_obj->cap->edit_post, $_user->ID, $object_id );
+                        $reqd_caps = map_meta_cap( 'edit_post', $_user->ID, $object_id );
                         $author_notify = ! array_diff( $reqd_caps, array_keys( array_intersect( $_user->allcaps, array( true, 1, '1' ) ) ) );
                     }
     
@@ -481,8 +481,8 @@ class Rvy_Revision_Workflow_UI {
                     if ( $recipient_ids && $type_obj ) {
                         foreach( $recipient_ids as $key => $user_id ) {
                             $_user = new WP_User($user_id);
-                            $reqd_caps = map_meta_cap( $type_obj->cap->edit_post, $user_id, $published_post->ID );
-                            
+                            $reqd_caps = map_meta_cap( 'edit_post', $user_id, $published_post->ID );
+
                             if ( array_diff( $reqd_caps, array_keys( array_intersect( $_user->allcaps, array( true, 1, '1' ) ) ) ) ) {
                                 unset( $recipient_ids[$key] );
                             }


### PR DESCRIPTION
This simplifies numerous capability checks, eliminates redundant execution because the WordPress function already:

* Converts $cap->edit_post to 'edit_post' if the post type supports meta capability mapping

* Converts 'edit_post' to $cap->edit_post if the post type does not support meta capability mapping