### PR TITLE
New capability required to see or edit other users' unsubmitted revisions

### DIFF
--- a/admin/admin_rvy.php
+++ b/admin/admin_rvy.php
@@ -226,7 +226,7 @@ class RevisionaryAdmin
 	}
 
 	public function fltPublishPressCapsSection($section_caps) {
-		$section_caps['PublishPress Revisions'] = ['edit_others_drafts', 'edit_others_revisions', 'list_others_revisions'];
+		$section_caps['PublishPress Revisions'] = ['edit_others_drafts', 'edit_others_revisions', 'list_others_revisions', 'manage_unsubmitted_revisions'];
 		return $section_caps;
 	}
 

--- a/admin/class-list-table_rvy.php
+++ b/admin/class-list-table_rvy.php
@@ -286,7 +286,11 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 			$own_revision_clause = '';
 		}
 
-		$revision_status_clause = (!empty($args['revision_query']) && empty($_REQUEST['all'])) ? "AND $p.post_mime_type != 'draft-revision' " : '';
+		if (!empty($args['revision_query']) && empty($_REQUEST['all'])) {
+			$revision_status_clause = "AND $p.post_mime_type != 'draft-revision' ";
+		} elseif (!current_user_can("manage_unsubmitted_revisions")) {
+			$revision_status_clause = "AND ($p.post_mime_type != 'draft-revision' OR $p.post_author = '$current_user->ID')";
+		}
 
 		$where_append = "($p.comment_count IN ($post_id_csv) {$revision_status_clause}$own_revision_clause)";
 

--- a/rvy_init.php
+++ b/rvy_init.php
@@ -427,6 +427,8 @@ function pp_revisions_label($label_name) {
 			? 							__('%sMy Copies & Changes%s (%s)', 'revisionary') 
 			: 							__('%sMy Revisions%s (%s)', 'revisionary'),
 			
+			'my_published_posts'		=> __('%sMy Published Posts%s(%s)', 'revisionary'),
+
 			'queue_col_revision' 		=> __('Revision', 'revisionary'),
 			'queue_col_revised_by' 		=> __('Revised By', 'revisionary'),
 			'queue_col_revision_date' 	=> __('Revision Date', 'revisionary'),


### PR DESCRIPTION
The following capability is added by default to the Administrator role:
manage_unsubmitted_revisions

Other roles will be unable to see and edit other users' unsubmitted revisions unless this capability is added.