### PR TITLE
Revisions 3: Exceptions for revision submission don't enable Revision creation

### DIFF
--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -609,7 +609,9 @@ class Revisionary
 			}
 
 			// allow PublishPress Permissions to apply 'copy' exceptions
-			if ($can_copy = apply_filters('revisionary_can_copy', $can_copy, $post_id, 'draft', 'draft-revision', $filter_args)) {
+			if ($can_copy = apply_filters('revisionary_can_copy', $can_copy, $post_id, 'draft', 'draft-revision', $filter_args)
+			|| apply_filters('revisionary_can_submit', $can_copy, $post_id, 'pending', 'pending-revision', $filter_args)
+			) {
 				$caps = ['read'];
 			}
 		


### PR DESCRIPTION
Fixes #485

Also requires PublishPress Permission fix:
https://github.com/publishpress/PublishPress-Permissions/pull/486