### PR TITLE
Fix unsubmitted revisions management access control

### DIFF
--- a/admin/class-list-table_rvy.php
+++ b/admin/class-list-table_rvy.php
@@ -310,7 +310,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 		)) || !empty($args['my_published_count'])) {
 			$revision_status_clause = "AND $p.post_mime_type != 'draft-revision' ";
 
-		} elseif (($is_my_activity && !$is_count_query) || !current_user_can("manage_unsubmitted_revisions")) {
+		} elseif (($is_my_activity && !$is_count_query) || (rvy_get_option('manage_unsubmitted_capability') && !current_user_can("manage_unsubmitted_revisions"))) {
 			$revision_status_clause = "AND ($p.post_mime_type != 'draft-revision' OR $p.post_author = '$current_user->ID')";
 		} else {
 			$revision_status_clause = '';

--- a/admin/options.php
+++ b/admin/options.php
@@ -116,6 +116,7 @@ $future_revision_singular = pp_revisions_status_label('future-revision', 'name')
 $this->option_captions = apply_filters('revisionary_option_captions',
 	[
 	'revision_statuses_noun_labels' =>			__('Use alternate labeling: "Working Copy" > "Change Request" > "Scheduled Change"', 'revisionary'),
+	'manage_unsubmitted_capability' =>			sprintf(__('Additional role capability required to manage %s'), pp_revisions_status_label('draft-revision', 'plural')),
 	'copy_posts_capability' =>					rvy_get_option('revision_statuses_noun_labels') ? __("Additional role capability required to create a Working Copy", 'revisionary') : __("Additional role capability required to create a new revision", 'revisionary'),
 	'caption_copy_as_edit' =>					sprintf(__('Posts / Pages list: Use "Edit" caption for %s link'), pp_revisions_status_label('draft-revision', 'submit_short')),
 	'pending_revisions' => 						sprintf(__('Enable %s', 'revisionary'), $pending_revision_plural),
@@ -168,7 +169,7 @@ $this->form_options = apply_filters('revisionary_option_sections', [
 	'license' =>			 ['edd_key'],
 	'role_definition' => 	 ['revisor_role_add_custom_rolecaps', 'require_edit_others_drafts'],
 	'revision_statuses' =>	 ['revision_statuses_noun_labels'],
-	'working_copy' =>		 ['copy_posts_capability', 'caption_copy_as_edit'],
+	'working_copy' =>		 ['manage_unsubmitted_capability', 'copy_posts_capability', 'caption_copy_as_edit'],
 	'scheduled_revisions' => ['scheduled_revisions', 'async_scheduled_publish', 'scheduled_revision_update_post_date', 'scheduled_revision_update_modified_date'],
 	'pending_revisions'	=> 	 ['pending_revisions', 'revise_posts_capability', 'pending_revision_update_post_date', 'pending_revision_update_modified_date'],
 	'revision_queue' =>		 ['revisor_lock_others_revisions', 'revisor_hide_others_revisions', 'admin_revisions_to_own_posts', 'list_unsubmitted_revisions'],
@@ -408,6 +409,13 @@ if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 		<?php _e('To expand the Posts / Pages listing for non-Editors, add capabilities: list_others_pages, list_published_posts, etc.', 'revisionary'); ?>
 		</div><br />
 	<?php endif;
+
+	$hint = __('To enable a role, add the manage_unsubmitted_revisions capability', 'revisionary');
+	$this->option_checkbox('manage_unsubmitted_capability', $tab, $section, $hint, '');
+
+	?>
+	<br />
+	<?php
 
 	$hint = sprintf(__('If the user does not have a regular Edit link, recaption the %s link as "Edit"', 'revisionary'), pp_revisions_status_label('draft-revision', 'submit_short'));
 	$this->option_checkbox( 'caption_copy_as_edit', $tab, $section, $hint, '' );

--- a/defaults_rvy.php
+++ b/defaults_rvy.php
@@ -13,6 +13,7 @@ if( basename(__FILE__) == basename($_SERVER['SCRIPT_FILENAME']) )
 // Setting scope: For Network installations, which Revisionary options should default to site-wide control?
 function rvy_default_options_sitewide() {
 	$def = array(
+		'manage_unsubmitted_capability' => true,
 		'copy_posts_capability' => true,
 		'revision_statuses_noun_labels' => true,
 		'caption_copy_as_edit' => true,
@@ -63,6 +64,7 @@ function rvy_default_options_sitewide() {
 // Default values for Revisionary settings
 function rvy_default_options() {
 	$def = array(
+		'manage_unsubmitted_capability' => 0,
 		'copy_posts_capability' => 0,
 		'revision_statuses_noun_labels' => 0,
 		'caption_copy_as_edit' => 0,


### PR DESCRIPTION
The manage_unsubmitted_revisions capability was required without any hint in plugin settings; Now not required unless configured in Revisions > Settings