### PR TITLE
Revision Queue: on bulk action, undefined function get_current_screen()

### DIFF
--- a/admin/admin-init_rvy.php
+++ b/admin/admin-init_rvy.php
@@ -242,7 +242,10 @@ function rvy_admin_init() {
 				break;
 	
 			default:
-				$sendback = apply_filters( 'handle_bulk_actions-' . get_current_screen()->id, $sendback, $doaction, $post_ids );
+				if (function_exists('get_current_screen')) {
+					$sendback = apply_filters( 'handle_bulk_actions-' . get_current_screen()->id, $sendback, $doaction, $post_ids );
+				}
+				
 				break;
 		}
 	


### PR DESCRIPTION
This error occured under some undisclosed site conditions.

Fixes #593