### PR TITLE
API: Additional filter arguments

### DIFF
--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -351,7 +351,7 @@ function rvy_revision_approve($revision_id = 0) {
 			
 			if ( $db_action && rvy_get_option( 'rev_approval_notify_admin' ) ) {
 				require_once(dirname(REVISIONARY_FILE).'/revision-workflow_rvy.php');
-				$admin_ids = apply_filters('revisionary_approval_notify_admin', Rvy_Revision_Workflow_UI::getRecipients('rev_approval_notify_admin', ['type_obj' => $type_obj, 'published_post' => $post]));
+				$admin_ids = apply_filters('revisionary_approval_notify_admin', Rvy_Revision_Workflow_UI::getRecipients('rev_approval_notify_admin', ['type_obj' => $type_obj, 'published_post' => $post]), ['post_type' => $type_obj->name, 'post_id' => $post->ID, 'revision_id' => $revision->ID]);
 
 				foreach($admin_ids as $user_id) {
 					if ($user = new WP_User($user_id)) {

--- a/revision-workflow_rvy.php
+++ b/revision-workflow_rvy.php
@@ -178,7 +178,7 @@ class Rvy_Revision_Workflow_UI {
 
             if ( $admin_notify ) {
                 // establish the publisher recipients
-                $recipient_ids = apply_filters('revisionary_submission_notify_admin', self::getRecipients('rev_submission_notify_admin', compact('type_obj', 'published_post')));
+                $recipient_ids = apply_filters('revisionary_submission_notify_admin', self::getRecipients('rev_submission_notify_admin', compact('type_obj', 'published_post')), ['post_type' => $object_type, 'post_id' => $published_post->ID, 'revision_id' => $revision_id]);
                 
                 if ( ( 'always' != $admin_notify ) && $selected_recipients ) {
                     // intersect default recipients with selected recipients


### PR DESCRIPTION
Pass post_type, post_id, revision_id arguments in "revisionary_approval_notify_admin" and "revisionary_submission_notify_admin" filters