### PR TITLE
WP 5.9: Approval button disabled after revision update

### DIFF
--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -542,8 +542,10 @@ function rvy_apply_revision( $revision_id, $actual_revision_status = '' ) {
 		return $revision;
 	}
 
-	if (! $published_id = rvy_post_id($revision_id)) {
-		return false;
+	if (!$published_id = $revision->comment_count) {
+		if (! $published_id = rvy_post_id($revision_id)) {
+			return false;
+		}
 	}
 
 	if ('revision' == get_post_field('post_type', $published_id)) {


### PR DESCRIPTION
Fixes #645