### PR TITLE
Scheduled Revisions: "Reload" link was broken by output escaping

### DIFF
--- a/front_rvy.php
+++ b/front_rvy.php
@@ -356,8 +356,9 @@ class RevisionaryFront {
 					$class = 'future';
 
 					// work around quirk of new scheduled revision preview not displaying page template and post thumbnail when accessed immediately after creation
-					if (time() < strtotime($post->post_modified_gmt) + 15 && !empty($_SERVER['HTTP_HOST']) && !empty($_SERVER['REQUEST_URI'])) {
-						$current_url = set_url_scheme( esc_url('https://' . esc_url_raw($_SERVER['HTTP_HOST']). esc_url_raw($_SERVER['REQUEST_URI'])) );
+					if (time() < strtotime($post->post_modified_gmt) + 5 && !empty($_SERVER['HTTP_HOST']) && !empty($_SERVER['REQUEST_URI'])) {
+						$current_url = esc_url(esc_url_raw($_SERVER['HTTP_HOST']). esc_url_raw($_SERVER['REQUEST_URI']));
+						
 						$title = esc_attr(esc_html__('This revision is very new, preview may not be synchronized with theme.', 'revisionary'));
 						$reload_link = " <a href='$current_url' title='$title'>" . esc_html__('Reload', 'revisionary') . '</a>';
 					} else {


### PR DESCRIPTION
This link is displayed only for scheduled revisions previewed shortly after creation.  Before the next release, we'll review whether the new scheduling mechanism eliminates the need for this workaround.

In the past, there were cases (probably due to caching performance on the server) where the page template and post thumbnail were not displayed when the preview is accessed immediately after creation.