### PR TITLE
WP 5.9: Revisors get access to Appearance menu

### DIFF
--- a/revisionary.php
+++ b/revisionary.php
@@ -257,7 +257,10 @@ add_action(
 
 		// since sequence of set_current_user and init actions seems unreliable, make sure our current_user is loaded first
 		add_action('init', 'rvy_init', 1);
+		
 		add_action('init', 'rvy_add_revisor_custom_caps', 99);
+		add_action('wp_loaded', 'rvy_add_revisor_custom_caps', 99);
+		
 		add_action('init', 'rvy_configuration_late_init', PHP_INT_MAX - 1);
 
 		revisionary();

--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -304,7 +304,7 @@ class Revisionary
 			'revisionary_enabled_post_types', 
 			array_diff_key(
 				$enabled_post_types,
-				['attachment' => true, 'tablepress_table' => true, 'acf-field-group' => true, 'acf-field' => true]
+				['attachment' => true, 'tablepress_table' => true, 'acf-field-group' => true, 'acf-field' => true, 'nav_menu_item' => true, 'custom_css' => true, 'customize_changeset' => true, 'wp_template' => true, 'wp_template_part' => true, 'wp_global_styles' => true, 'wp_navigation' => true]
 			)
 		);
 

--- a/rvy_init.php
+++ b/rvy_init.php
@@ -513,24 +513,11 @@ function rvy_add_revisor_custom_caps() {
 
 	global $wp_roles, $revisionary;
 
-	$custom_types = get_post_types(['public' => true, '_builtin' => false], 'object');
-
-	if (!defined('REVISIONARY_NO_PRIVATE_TYPES')) {
-		$private_types = array_merge(
-			get_post_types(['public' => false], 'object'), 
-			get_post_types(['public' => null], 'object')
-		);
+	$custom_types = array_intersect_key(
+		get_post_types(['_builtin' => false], 'object'),
+		$revisionary->enabled_post_types
+	);
 		
-		// by default, enable non-public post types that have type-specific capabilities defined
-		foreach($private_types as $post_type => $type_obj) {
-			if ((!empty($type_obj->cap) && !empty($type_obj->cap->edit_posts) && !in_array($type_obj->cap->edit_posts, ['edit_posts', 'edit_pages']))
-			|| defined('REVISIONARY_ENABLE_' . strtoupper($post_type) . '_TYPE')
-			) {
-				$custom_types[$post_type] = $type_obj;
-			}
-		}
-	}
-
 	if ( isset( $wp_roles->roles['revisor'] ) ) {
 		if ($custom_types) {
 			foreach( $custom_types as $post_type => $type_obj ) {


### PR DESCRIPTION
Fixes #690

Don't give Revisors capabilities for WordPress features that are now represented by private post types.

Also ensure that capabilities are granted for late-registered custom post types.