### PR TITLE
Classic Editor not detected based on use_block_editor_for_post filter

### DIFF
--- a/utils.php
+++ b/utils.php
@@ -112,7 +112,8 @@ class Utils {
 		$conditions[] = (self::isWp5() || $pluginsState['gutenberg'])
 						&& ! $pluginsState['classic-editor']
 						&& ! $pluginsState['gutenberg-ramp']
-						&& apply_filters('use_block_editor_for_post_type', true, $postType, PHP_INT_MAX);
+						&& apply_filters('use_block_editor_for_post_type', true, $postType, PHP_INT_MAX)
+						&& apply_filters('use_block_editor_for_post', true, get_post(rvy_detect_post_id()), PHP_INT_MAX);
 
 		$conditions[] = self::isWp5()
                         && $pluginsState['classic-editor']


### PR DESCRIPTION
False values passed through the "use_block_editor_for_post" filter did not cause Revisions to detect Classic Editor usage.