### PR TITLE
Implement this fix only if constant is defined

### DIFF
--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -813,7 +813,7 @@ function rvy_apply_revision( $revision_id, $actual_revision_status = '' ) {
 	}
 
 	if ($published_id != $revision_id) {
-		if (defined('REVISIONARY_ARCHIVE_SCHEDULED_REVISION')) {
+		if (!defined('REVISIONARY_NO_SCHEDULED_REVISION_ARCHIVE')) {
 			$wpdb->update(
 				$wpdb->posts, 
 				['post_type' => 'revision', 


### PR DESCRIPTION
Since this workaround stops scheduled revisions from being maintained as regular past revisions, use it only if the following constant is defined:

REVISIONARY_NO_SCHEDULED_REVISION_ARCHIVE