### PR TITLE
Scheduled Revision publication fails without explanation if DISABLE_WP_CRON defined

### DIFF
--- a/admin/admin_rvy.php
+++ b/admin/admin_rvy.php
@@ -107,6 +107,14 @@ class RevisionaryAdmin
 		
 			if (($pagenow == 'admin.php') && isset($_GET['page']) && in_array($_GET['page'], ['revisionary-q', 'revisionary-settings'])
 			) {
+				global $wp_version;
+
+				if (defined('DISABLE_WP_CRON') && rvy_get_option('scheduled_revisions', -1, false, ['bypass_condition_check' => true]) 
+				&& rvy_get_option('scheduled_publish_cron')
+				) {
+					rvy_notice('Scheduled Revisions are not available because WP-Cron is disabled on this site.');
+				}
+
 				if (!class_exists('\PublishPress\WordPressReviews\ReviewsController')) {
 					include_once RVY_ABSPATH . '/vendor/publishpress/wordpress-reviews/ReviewsController.php';
 				}

--- a/admin/options.php
+++ b/admin/options.php
@@ -46,7 +46,7 @@ class RvyOptionUI {
 		if ( in_array( $option_name, $this->form_options[$tab_name][$section_name] ) ) {
 			$this->all_options []= $option_name;
 
-			$return['val'] = rvy_get_option($option_name, $this->sitewide, $this->customize_defaults);
+			$return['val'] = rvy_get_option($option_name, $this->sitewide, $this->customize_defaults, ['bypass_condition_check' => true]);
 
 			echo "<div class='agp-vspaced_input'";
 			echo (isset($args['style']) && $args['style']) ? " style='" . esc_attr($args['style']) . "'" : '';
@@ -564,13 +564,11 @@ if ( 	// To avoid confusion, don't display any revision settings if pending revi
 		$this->option_checkbox( 'scheduled_revision_update_modified_date', $tab, $section, $hint, '' );
 
 		global $wp_version;
+		
+		$hint = esc_html__( 'Publish scheduled revisions using the WP-Cron mechanism. On some sites, publication will fail if this setting is disabled.', 'revisionary' );
+		$this->option_checkbox( 'scheduled_publish_cron', $tab, $section, $hint, '' );
 
-		if (version_compare($wp_version, '5.9', '<')) {
-			$hint = esc_html__( 'Publish scheduled revisions using the WP-Cron mechanism.', 'revisionary' );
-			$this->option_checkbox( 'scheduled_publish_cron', $tab, $section, $hint, '' );
-		}
-
-		if (!rvy_get_option('scheduled_publish_cron') && version_compare($wp_version, '5.9', '<')) {
+		if (!rvy_get_option('scheduled_publish_cron')) {
 			$hint = esc_html__( 'Publish scheduled revisions asynchronously, via a secondary http request from the server.  This is usually best since it eliminates delay, but some servers may not support it.', 'revisionary' );
 			$this->option_checkbox( 'async_scheduled_publish', $tab, $section, $hint, '' );
 		}
@@ -678,7 +676,7 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 			'</a>'
 		);
 		?>
-
+		
 		</div>
 		<?php endif;?>
 
@@ -822,7 +820,7 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 		}
 
 		if (!empty($_SERVER['REQUEST_URI'])) {
-		$uri = esc_url(esc_url_raw($_SERVER['REQUEST_URI']));
+			$uri = esc_url(esc_url_raw($_SERVER['REQUEST_URI']));
 		} else {
 			$uri = '';
 		}

--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -1206,7 +1206,7 @@ function rvy_publish_scheduled_revisions($args = []) {
 		remove_action( 'wp_insert_post', 'relevanssi_insert_edit', 99, 1 );
 	}
 
-	if (!rvy_get_option('scheduled_publish_cron') && version_compare($wp_version, '5.9', '<')) {
+	if (!rvy_get_option('scheduled_publish_cron')) {
 		rvy_confirm_async_execution( 'publish_scheduled_revisions' );
 	
 		// Prevent this function from being triggered simultaneously by another site request
@@ -1457,7 +1457,7 @@ function rvy_publish_scheduled_revisions($args = []) {
 		}
 	}
 
-	if (!rvy_get_option('scheduled_publish_cron') && version_compare($wp_version, '5.9', '<')) {
+	if (!rvy_get_option('scheduled_publish_cron')) {
 		rvy_update_next_publish_date();
 	}
 
@@ -1475,7 +1475,7 @@ function rvy_publish_scheduled_revisions($args = []) {
 function rvy_update_next_publish_date($args = []) {
 	global $wpdb, $wp_version;
 	
-	if ($args && !empty($args['revision_id']) && (rvy_get_option('scheduled_publish_cron') || version_compare($wp_version, '5.9', '>='))) {
+	if ($args && !empty($args['revision_id']) && rvy_get_option('scheduled_publish_cron')) {
 		if ($revision = get_post($args['revision_id'])) {
 			wp_schedule_single_event(strtotime( $revision->post_date_gmt ), 'publish_revision_rvy', array_intersect_key($args, ['revision_id' => true]));
 		}


### PR DESCRIPTION
Fixes #771

Also allow usage of alternate scheduled publication method with any WP version.