### PR TITLE
Filter to ignore DISABLE_WP_CRON constant

### DIFF
--- a/admin/admin_rvy.php
+++ b/admin/admin_rvy.php
@@ -110,7 +110,7 @@ class RevisionaryAdmin
 				global $wp_version;
 
 				if (defined('DISABLE_WP_CRON') && DISABLE_WP_CRON && rvy_get_option('scheduled_revisions', -1, false, ['bypass_condition_check' => true]) 
-				&& rvy_get_option('scheduled_publish_cron')
+				&& rvy_get_option('scheduled_publish_cron') && apply_filters('revisionary_wp_cron_disabled', true)
 				) {
 					rvy_notice('Scheduled Revisions are not available because WP-Cron is disabled on this site.');
 				}

--- a/rvy_init.php
+++ b/rvy_init.php
@@ -910,7 +910,7 @@ function rvy_get_option($option_basename, $sitewide = -1, $get_default = false, 
 	}
 	
 	if (('scheduled_revisions' == $option_basename) && empty($args['bypass_condition_check']) 
-	&& defined('DISABLE_WP_CRON') && DISABLE_WP_CRON && rvy_get_option('scheduled_publish_cron')
+	&& defined('DISABLE_WP_CRON') && DISABLE_WP_CRON && rvy_get_option('scheduled_publish_cron') && apply_filters('revisionary_wp_cron_disabled', true)
 	) {
 		return false;
 	}


### PR DESCRIPTION
Some sites may use wp-cron but handle timed execution with wp-cli / custom code.

Fixes #786