### PR TITLE
Option to require restore_revisions capability for non-Admins

### DIFF
--- a/admin/admin_rvy.php
+++ b/admin/admin_rvy.php
@@ -344,6 +344,11 @@ class RevisionaryAdmin
 
 	public function fltPublishPressCapsSection($section_caps) {
 		$section_caps['PublishPress Revisions'] = ['edit_others_drafts', 'edit_others_revisions', 'list_others_revisions', 'manage_unsubmitted_revisions'];
+
+		if (defined('PUBLISHPRESS_REVISIONS_PRO_VERSION') && rvy_get_option('revision_restore_require_cap')) {
+			$section_caps['PublishPress Revisions'] []= 'restore_revisions';
+		}
+
 		return $section_caps;
 	}
 

--- a/admin/history_rvy.php
+++ b/admin/history_rvy.php
@@ -49,8 +49,11 @@ class RevisionaryHistory
         // Hide Restore button if user does not have permission
         if ($_post = get_post($revision_id)) {
             if (!rvy_in_revision_workflow($_post)) {
-                if ($parent_post = get_post($_post->post_parent)) {
-                    if (!$revisionary->canEditPost($parent_post)) :
+                $parent_post = get_post($_post->post_parent);
+
+                if (($parent_post && !$revisionary->canEditPost($parent_post))
+                || (rvy_get_option('revision_restore_require_cap') && !current_user_can('administrator') && !is_super_admin() && !current_user_can('restore_revisions'))
+                ) :
         ?>
 						<style type='text/css'>
 				        input.restore-revision {display:none !important;}
@@ -58,7 +61,6 @@ class RevisionaryHistory
 				        <?php
 
                     endif;
-                }
             }
         }
     }

--- a/admin/options.php
+++ b/admin/options.php
@@ -155,6 +155,7 @@ $this->option_captions = apply_filters('revisionary_option_captions',
 	'rev_publication_delete_ed_comments' =>		esc_html__('On Revision publication, delete Editorial Comments', 'revisionary'),
 	'deletion_queue' => 						esc_html__('Enable deletion queue', 'revisionary'),
 	'revision_archive_deletion' => 				esc_html__('Enable deletion in Revision Archive', 'revisionary'),
+	'revision_restore_require_cap' =>			esc_html__('Revision Restore: Non-Administrators need capability', 'revisionary'),
 	]
 );
 
@@ -181,7 +182,7 @@ $this->form_options = apply_filters('revisionary_option_sections', [
 	'pending_revisions'	=> 	 ['pending_revisions', 'revise_posts_capability', 'pending_revision_update_post_date', 'pending_revision_update_modified_date'],
 	'revision_queue' =>		 ['revisor_lock_others_revisions', 'revisor_hide_others_revisions', 'admin_revisions_to_own_posts', 'list_unsubmitted_revisions'],
 	'preview' =>			 ['revision_preview_links', 'preview_link_type', 'preview_link_alternate_preview_arg', 'compare_revisions_direct_approval'],
-	'revisions'		=>		 ['trigger_post_update_actions', 'copy_revision_comments_to_post', 'diff_display_strip_tags', 'past_revisions_order_by', 'rev_publication_delete_ed_comments', 'deletion_queue', 'revision_archive_deletion', 'display_hints'],
+	'revisions'		=>		 ['trigger_post_update_actions', 'copy_revision_comments_to_post', 'diff_display_strip_tags', 'past_revisions_order_by', 'rev_publication_delete_ed_comments', 'deletion_queue', 'revision_archive_deletion', 'revision_restore_require_cap', 'display_hints'],
 	'notification'	=>		 ['pending_rev_notify_admin', 'pending_rev_notify_author', 'revision_update_notifications', 'rev_approval_notify_admin', 'rev_approval_notify_author', 'rev_approval_notify_revisor', 'publish_scheduled_notify_admin', 'publish_scheduled_notify_author', 'publish_scheduled_notify_revisor', 'use_notification_buffer'],
 ]
 ]);
@@ -771,6 +772,11 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 
 		$hint = '';
 		$this->option_checkbox( 'revision_archive_deletion', $tab, $section, $hint, '' );
+
+		if (defined('PUBLISHPRESS_REVISIONS_PRO_VERSION')) {
+			$hint = esc_html__('Non-Administrators cannot restore a revision without the restore_revisions capability', 'revisionary');
+			$this->option_checkbox( 'revision_restore_require_cap', $tab, $section, $hint, '' );
+		}
 		?>
 
 		</td></tr></table>

--- a/defaults_rvy.php
+++ b/defaults_rvy.php
@@ -58,6 +58,7 @@ function rvy_default_options_sitewide() {
 		'rev_publication_delete_ed_comments' => true,
 		'deletion_queue' => true,
 		'revision_archive_deletion' => true,
+		'revision_restore_require_cap' => true,
 		'revision_limit_per_post' => true,
 	);
 
@@ -116,6 +117,7 @@ function rvy_default_options() {
 		'rev_publication_delete_ed_comments' => 0,
 		'deletion_queue' => 0,
 		'revision_archive_deletion' => 0,
+		'revision_restore_require_cap' => 0,
 		'revision_limit_per_post' => 0,
 	);
 


### PR DESCRIPTION
The revision restore operation affected by this capability check is normally done on the Compare Revisions or Revision Archive screen.