### PR TITLE
WP-defined limit for past revisions bypassed on revision publication

### DIFF
--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -861,6 +861,8 @@ function rvy_apply_revision( $revision_id, $actual_revision_status = '' ) {
 				],
 				['ID' => $revision_id]
 			);
+
+			Revisionary::applyRevisionLimit($published);
 		} else {
 			wp_delete_post($revision_id, true);
 		}

--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -1136,4 +1136,54 @@ class Revisionary
 
         return $statuses;
     }
+
+	static function applyRevisionLimit($post) {
+		if (!is_object($post) || empty($post->ID)) {
+			return;
+		}
+
+		$post_id = $post->ID;
+
+		/*
+		* If a limit for the number of revisions to keep has been set,
+		* delete the oldest ones.
+		*/
+		$revisions_to_keep = wp_revisions_to_keep( $post );
+
+		if ( $revisions_to_keep < 0 ) {
+			return;
+		}
+
+		$revisions = wp_get_post_revisions( $post_id, array( 'order' => 'ASC' ) );
+
+		/**
+		 * Filters the revisions to be considered for deletion.
+		 *
+		 * @since 6.2.0
+		 *
+		 * @param WP_Post[] $revisions Array of revisions, or an empty array if none.
+		 * @param int       $post_id   The ID of the post to save as a revision.
+		 */
+		$revisions = apply_filters(
+			'wp_save_post_revision_revisions_before_deletion',
+			$revisions,
+			$post_id
+		);
+
+		$delete = count( $revisions ) - $revisions_to_keep;
+
+		if ( $delete < 1 ) {
+			return $return;
+		}
+
+		$revisions = array_slice( $revisions, 0, $delete );
+
+		for ( $i = 0; isset( $revisions[ $i ] ); $i++ ) {
+			if ( str_contains( $revisions[ $i ]->post_name, 'autosave' ) ) {
+				continue;
+			}
+
+			wp_delete_post_revision( $revisions[ $i ]->ID );
+		}
+	}
 } // end Revisionary class


### PR DESCRIPTION
When saving currently published content as a past revision at pending / scheduled revision publication, the limit specified by WP_POST_REVISIONS was ignored.