### PR TITLE
Fix headers already sent.

### DIFF
--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -137,11 +137,11 @@ class Revisionary
 
 		// This is needed, implemented for pending revisions only
 		if (!empty($_REQUEST['get_new_revision'])) {
-			add_action('admin_enqueue_scripts', array($this, 'act_new_revision_redirect'));
+			add_action('init', array($this, 'act_new_revision_redirect'));
 		}
 
 		if (!empty($_REQUEST['edit_new_revision'])) {
-			add_action('admin_enqueue_scripts', array($this, 'act_edit_revision_redirect'));
+			add_action('template_redirect', array($this, 'act_edit_revision_redirect'));
 		}
 
 		add_filter('get_comments_number', array($this, 'flt_get_comments_number'), 10, 2);


### PR DESCRIPTION
To reproduce bug

- Edit a page and click New Revision.
- Click the Preview or Edit button that appears.
- You will be redirected to the wrong page and see either a white screen or the 'Headers already sent' error message.