### PR TITLE
"Schedule Revision" button captioning does not account for time zone differences

### DIFF
--- a/admin/post-edit-block-ui_rvy.php
+++ b/admin/post-edit-block-ui_rvy.php
@@ -108,6 +108,13 @@ class RVY_PostBlockEditUI {
             $args = \PublishPress\Revisions\PostEditorWorkflowUI::postLinkParams(compact('post', 'do_pending_revisions', 'do_scheduled_revisions'));
         }
 
+        $wp_timezone = wp_timezone();
+        $utc_timezone = new DateTimeZone('UTC');
+        $wp_time = new DateTime("now", $wp_timezone);
+        $utc_time = new DateTime("now", new DateTimeZone('UTC'));
+
+        $args['timezoneOffset'] = 0 - $wp_timezone->getOffset($utc_time);
+
         wp_localize_script( 'rvy_object_edit', 'rvyObjEdit', $args );
     }
 

--- a/admin/rvy_post-block-edit.dev.js
+++ b/admin/rvy_post-block-edit.dev.js
@@ -275,9 +275,11 @@ jQuery(document).ready( function($) {
 		selectedDateHTML = wp.data.select('core/editor').getEditedPostAttribute('date');
 		var selectedDate = new Date( selectedDateHTML );
 
+		var currentDate = new Date();
 
-		RvyTimeSelection = selectedDate.getTime();
-		var tdiff = RvyTimeSelection - Date.now();
+		RvyTimeSelection = selectedDate.getTime() - ((currentDate.getTimezoneOffset() * 60 - rvyObjEdit.timezoneOffset) * 1000);
+
+		var tdiff = RvyTimeSelection - currentDate.getTime();
 
 		RvyTimeSelection = RvyTimeSelection / 1000; // pass seconds to server
 


### PR DESCRIPTION
Fixes #1284

Post Editor - "Schedule Revision" button captioning following date selection did not account for time zone difference between site and editing user