### PR TITLE
Security hardening

### DIFF
--- a/admin/admin-init_rvy.php
+++ b/admin/admin-init_rvy.php
@@ -403,7 +403,7 @@ function rvy_admin_init() {
 		
 				if (!empty($arr) && is_array($arr) && !empty($arr['code'])) {
 					if (!empty($_REQUEST['referer'])) {
-						$url = add_query_arg('revision_action', $arr['code'], $_REQUEST['referer']);
+						$url = add_query_arg('revision_action', $arr['code'], esc_url_raw($_REQUEST['referer']));
 						wp_redirect($url);
 						exit;
 					}

--- a/admin/admin-posts_rvy.php
+++ b/admin/admin-posts_rvy.php
@@ -36,7 +36,7 @@ class RevisionaryAdminPosts {
 
 					if (!$_post || (('trash' == $_post->post_status) && in_array($_post->post_mime_type, rvy_revision_statuses()))) {
 						if (apply_filters('revisionary_deletion_redirect_to_queue', true, $deleted_id, $post_type)) {
-							$url = admin_url("admin.php?page=revisionary-q&pp_revisions_deleted={$deleted_id}");
+							$url = wp_nonce_url(admin_url("admin.php?page=revisionary-q&pp_revisions_deleted={$deleted_id}"), 'revisions-deleted');
 							
 							if (!empty($_SERVER['REQUEST_URI']) && false === strpos(esc_url_raw($_SERVER['REQUEST_URI']), $url)) {
 								wp_redirect($url);
@@ -203,7 +203,8 @@ class RevisionaryAdminPosts {
 			}
 
 			if (rvy_get_option('pending_revisions') && current_user_can('copy_post', $post->ID) && !$revision_blocked) {
-				$referer_arg = '&referer=' . esc_url_raw($_SERVER['REQUEST_URI']);
+				$uri = isset($_SERVER['REQUEST_URI']) ? esc_url_raw($_SERVER['REQUEST_URI']) : '';
+				$referer_arg = '&referer=' . $uri;
 
 				//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$redirect_arg = ( ! empty($_REQUEST['rvy_redirect']) ) ? "&rvy_redirect=" . esc_url_raw($_REQUEST['rvy_redirect']) : '';
@@ -214,7 +215,7 @@ class RevisionaryAdminPosts {
 				$caption = (isset($actions['edit']) || !rvy_get_option('caption_copy_as_edit')) ? pp_revisions_status_label('draft-revision', 'submit') : esc_html__('Edit');
 				$caption = str_replace(' ', '&nbsp;', $caption);
 
-				$actions['create_revision'] = "<a href='$url'>" . $caption . '</a>';
+				$actions['create_revision'] = "<a href='" . esc_url($url) . "'>" . $caption . '</a>';
 			}
 		}
 

--- a/admin/class-list-table_rvy.php
+++ b/admin/class-list-table_rvy.php
@@ -48,7 +48,10 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 		if ($triggered_deletions = (array) get_option('_rvy_trigger_deletion')) {
 			$clear_trigger_option = true;
 		}
+
 		if (!empty($_REQUEST['pp_revisions_deleted'])) {
+			check_admin_referer('revisions-deleted');
+
 			global $current_user;
 			
 			$delete_id = (int) $_REQUEST['pp_revisions_deleted'];
@@ -609,7 +612,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 				$post_type = get_post_field('post_type', $post_id);
 
 				if ( $type_obj = get_post_type_object( $post_type ) ) {
-					$link = add_query_arg('post_type', $type_obj->name, $request_url);
+					$link = add_query_arg('post_type', $type_obj->name, esc_url($request_url));
 					echo "<a href='" . esc_url($link) . "'>" . esc_html($type_obj->labels->singular_name) . "</a>";
 				} else {
 					echo esc_html("($post_type)");
@@ -624,7 +627,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 					$label = ucwords($post->post_mime_type);
 				}
 
-				$link = add_query_arg('post_status', $post->post_mime_type, $request_url);
+				$link = add_query_arg('post_status', $post->post_mime_type, esc_url($request_url));
 				echo "<a href='" . esc_url($link) . "'>" . esc_html($label) . "</a>";
 
 				break;
@@ -691,7 +694,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 					$authors_str = [];
 					foreach ($authors as $author) {
 						if (is_object($author)) {
-							$url           = add_query_arg('post_author', $author->ID, $request_url);
+							$url           = add_query_arg('post_author', $author->ID, esc_url($request_url));
 							$authors_str[] = '<a href="' . esc_url($url) . '">' . esc_html($author->display_name) . '</a>';
 						}
 					}
@@ -705,7 +708,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 					echo implode(', ', $authors_str);  // output variables escaped above
 				} else {
 					$author_caption = get_the_author_meta('display_name', $parent_post->post_author);
-					$this->apply_edit_link(add_query_arg('post_author', $parent_post->post_author, $request_url), $author_caption);
+					$this->apply_edit_link(add_query_arg('post_author', $parent_post->post_author, esc_url($request_url)), $author_caption);
 				}
 
 				break;
@@ -744,7 +747,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 		$actions['list_filter'] = sprintf(
 			'<a href="%1$s" title="%2$s" aria-label="%2$s">%3$s</a>',
 
-			add_query_arg('published_post', $post->ID, $request_url),
+			add_query_arg('published_post', $post->ID, esc_url($request_url)),
 			/* translators: %s: post title */
 			esc_attr( sprintf( esc_html__( 'View only revisions of %s', 'revisionary' ), '&#8220;' . $post->post_title . '&#8221;' ) ),
 			esc_html__( 'Filter' )
@@ -1250,7 +1253,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 			} elseif ('cb' == $column_key) {
 				echo $column_display_name;									// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			} else {
-				echo $column_display_name;
+				echo esc_html($column_display_name);	
 			}
 
 			echo "</" . esc_attr($tag) .">";
@@ -1267,7 +1270,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 		if ( $can_edit_post && $post->post_status != 'trash' && $edit_link = get_edit_post_link( $post->ID )) {
 			printf(
 				'<a class="row-title" href="%s" aria-label="%s">%s%s</a>',
-				$edit_link,
+				esc_url($edit_link),
 				/* translators: %s: post title */
 				esc_attr( sprintf( esc_html__( '&#8220;%s&#8221; (Edit)' ), $title ) ),
 				'',
@@ -1313,7 +1316,7 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 		$request_url = add_query_arg($_REQUEST, rvy_admin_url('admin.php?page=revisionary-q'));				//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$args = ['author' => get_the_author_meta( 'ID' )];
-		$this->apply_edit_link( add_query_arg('author', $args['author'], $request_url), get_the_author() );
+		$this->apply_edit_link( add_query_arg('author', $args['author'], esc_url($request_url)), get_the_author() );
 	}
 
 	/**

--- a/admin/history_rvy.php
+++ b/admin/history_rvy.php
@@ -164,8 +164,6 @@ class RevisionaryHistory
 
                 $status_obj = get_post_status_object($revision->post_mime_type);
 
-                $post_edit_link = get_edit_post_link($published_post);
-                $post_title     = '<a href="' . $post_edit_link . '">' . _draft_or_post_title($published_post) . '</a>';
                 /* translators: %s: post title */
                 $do_h1 = true;
                 $title          = $status_obj->labels->plural;                              // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -196,13 +194,17 @@ class RevisionaryHistory
         <div class="wrap">
             <h1 class="long-header"><?php 
             if (!empty($do_h1)) {
-                printf( esc_html__( 'Compare %s of "%s"', 'revisionary' ), $status_obj->labels->plural, $post_title );
+                printf( 
+                    esc_html__( 'Compare %s of "%s"', 'revisionary' ), 
+                    esc_html($status_obj->labels->plural), 
+                    '<a href="' . esc_url(get_edit_post_link($published_post)) . '">' . esc_html(_draft_or_post_title($published_post)) . '</a>'
+                );
             }
             ?>
             </h1>
             <?php
-            if (!empty($post_edit_link)) {
-                echo '<a href="' . esc_url($post_edit_link) . '">' . esc_html__( 'Return to editor' ) . '</a>';
+            if (get_edit_post_link($published_post)) {
+                echo '<a href="' . esc_url(get_edit_post_link($published_post)) . '">' . esc_html__( 'Return to editor' ) . '</a>';
             }
             ?>
         </div>

--- a/admin/options.php
+++ b/admin/options.php
@@ -257,10 +257,10 @@ else
 </header>
 
 <?php
-$div_class = apply_filters('publishpress_revisions_settings_sidebar', '');
+$div_class = apply_filters('publishpress_revisions_settings_sidebar_class', '');
 ?>
 
-<div id="poststuff" class="metabox-holder <?php echo $div_class;?>">
+<div id="poststuff" class="metabox-holder <?php echo esc_attr($div_class);?>">
 
 	<?php do_action('publishpress_revisions_settings_sidebar');?>
 
@@ -669,7 +669,7 @@ if ( 	// To avoid confusion, don't display any revision settings if pending revi
 
 		<?php if (!empty($_SERVER['REQUEST_URI'])):?>
 		<p style="padding-left:22px; margin-top:25px">
-		<a href="<?php echo esc_url(add_query_arg('rvy_flush_flags', 1, esc_url(esc_url_raw($_SERVER['REQUEST_URI']))))?>"><?php esc_html_e('Regenerate "post has revision" flags', 'revisionary');?></a>
+		<a href="<?php echo esc_url(wp_nonce_url(add_query_arg('rvy_flush_flags', 1, esc_url(esc_url_raw($_SERVER['REQUEST_URI']))), 'flush-flags') )?>"><?php esc_html_e('Regenerate "post has revision" flags', 'revisionary');?></a>
 		</p>
 		<?php endif;?>
 
@@ -722,7 +722,7 @@ if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 					'The revision preview argument is configured by constant definition: %s',
 					'revisionary'
 				),
-				RVY_PREVIEW_ARG
+				esc_html(RVY_PREVIEW_ARG)
 			);
 		} else {
 			$hint = esc_html__('Adjust preview links to use "rv_preview" argument instead of "preview". Experiment to see which works best with your theme.', 'revisionary');
@@ -852,8 +852,9 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 
 				echo esc_html($this->option_captions[$id]);
 
+				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInTernaryCondition
 				echo ( defined('RVY_CONTENT_ROLES') && $group_link = $revisionary->content_roles->get_metagroup_edit_link( 'Pending Revision Monitors' ) ) ?
-				sprintf( " &bull;&nbsp;<a href='%s'>" . esc_html__('select recipients', 'revisionary') . "</a>", $group_link ) : '';
+				sprintf( " &bull;&nbsp;<a href='%s'>" . esc_html__('select recipients', 'revisionary') . "</a>", esc_url($group_link) ) : '';
 
 				echo "<br />";
 			}

--- a/admin/post-edit-block-ui_rvy.php
+++ b/admin/post-edit-block-ui_rvy.php
@@ -29,8 +29,10 @@ if ($_post_id = rvy_detect_post_id()) {
                 $wpdb->update($wpdb->posts, ['post_modified_gmt' => $_post->post_modified_gmt, 'post_modified' => $_post->post_modified], ['ID' => $_post->ID]);
 
                 if (!get_transient("revisionary-post-edit-redirect-{$_post_id}")) {
+                    $uri = (isset($_SERVER['REQUEST_URI'])) ? esc_url_raw($_SERVER['REQUEST_URI']) : '';
+
                     set_transient("revisionary-post-edit-redirect-{$_post_id}", true, 30);
-                    wp_redirect(esc_url_raw($_SERVER['REQUEST_URI']));
+                    wp_redirect(esc_url_raw($uri));
                     exit;
                 }
             }
@@ -166,7 +168,7 @@ class RVY_PostBlockEditUI {
             });
 
             $(document).on('change', 'div.rvy-author-selection select', function(e) {
-                var data = {'rvy_ajax_field': 'author_select', 'rvy_ajax_value': <?php echo $post->ID;?>, 'rvy_selection': $('div.rvy-author-selection select').val(), 'nc': Math.floor(Math.random() * 99999999)};
+                var data = {'rvy_ajax_field': 'author_select', 'rvy_ajax_value': <?php echo esc_attr($post->ID);?>, 'rvy_selection': $('div.rvy-author-selection select').val(), 'nc': Math.floor(Math.random() * 99999999)};
 
                 $('div.rvy-author-selection select').attr('disabled', 'disabled');
 

--- a/admin/post-edit_rvy.php
+++ b/admin/post-edit_rvy.php
@@ -163,7 +163,7 @@ class RvyPostEdit {
 
         ?>
         <a class="preview button" href="<?php echo esc_url($preview_link); ?>" target="revision-preview" id="revision-preview"
-           tabindex="4" title="<?php echo esc_html($preview_title);?>"><?php echo esc_html($preview_button); ?></a>
+           tabindex="4" title="<?php echo esc_attr($preview_title);?>"><?php echo esc_html($preview_button); ?></a>
         <?php
     }
 
@@ -277,7 +277,7 @@ class RvyPostEdit {
             //});
 
             $(document).on('change', 'div.rvy-author-selection select', function(e) {
-                var data = {'rvy_ajax_field': 'author_select', 'rvy_ajax_value': <?php echo $post->ID;?>, 'rvy_selection': $('div.rvy-author-selection select').val(), 'nc': Math.floor(Math.random() * 99999999)};
+                var data = {'rvy_ajax_field': 'author_select', 'rvy_ajax_value': <?php echo esc_attr($post->ID);?>, 'rvy_selection': $('div.rvy-author-selection select').val(), 'nc': Math.floor(Math.random() * 99999999)};
 
                 $('div.rvy-author-selection select').attr('disabled', 'disabled');
 

--- a/admin/post-editor-workflow-ui_rvy.php
+++ b/admin/post-editor-workflow-ui_rvy.php
@@ -209,9 +209,9 @@ class PostEditorWorkflowUI {
                 'creatingCaption' => pp_revisions_status_label('draft-revision', 'submitting'),
                 'completedCaption' => pp_revisions_status_label('draft-revision', 'submitted'),
                 'completedLinkCaption' => (!empty($type_obj->public)) ? $preview_caption : '',
-                'completedURL' => (!empty($type_obj->public)) ? rvy_nc_url( add_query_arg('get_new_revision', $post->ID, admin_url(''))) : '',
+                'completedURL' => (!empty($type_obj->public)) ? rvy_nc_url( wp_nonce_url(add_query_arg('get_new_revision', $post->ID, admin_url('')), 'new-revision') ) : '',
                 'completedEditLinkCaption' => $edit_caption,
-                'completedEditURL' => rvy_nc_url( add_query_arg(['edit_new_revision' => $post->ID, 'published_post' => $post->ID], admin_url('admin.php?page=revisionary-q'))),
+                'completedEditURL' => rvy_nc_url( wp_nonce_url(add_query_arg(['edit_new_revision' => $post->ID, 'published_post' => $post->ID], admin_url('admin.php?page=revisionary-q')), 'edit-new-revision') ),
                 'errorCaption' => esc_html__('Error Creating Revision', 'revisionary'),
                 'ajaxurl' => rvy_admin_url(''),
                 'update' => esc_html__('Update', 'revisionary'),
@@ -231,9 +231,9 @@ class PostEditorWorkflowUI {
                 'scheduleDisabledTitle' => esc_attr(sprintf(esc_html__('For custom field changes, edit a scheduled %s.', 'revisionary'), strtolower(pp_revisions_status_label('draft-revision', 'basic')))),
                 'scheduledCaption' => pp_revisions_status_label('future-revision', 'submitted'),
                 'scheduledLinkCaption' => (!empty($type_obj->public)) ? $preview_caption : '',
-                'scheduledURL' => (!empty($type_obj->public)) ? rvy_nc_url( add_query_arg('get_new_revision', $post->ID, admin_url(''))) : '',
+                'scheduledURL' => (!empty($type_obj->public)) ? rvy_nc_url( wp_nonce_url(add_query_arg('get_new_revision', $post->ID, admin_url('')), 'new-revision') ) : '',
                 'scheduledEditLinkCaption' => $edit_caption,
-                'scheduledEditURL' => rvy_nc_url( add_query_arg(['edit_new_revision' => $post->ID, 'published_post' => $post->ID], admin_url('admin.php?page=revisionary-q'))),
+                'scheduledEditURL' => rvy_nc_url( wp_nonce_url(add_query_arg(['edit_new_revision' => $post->ID, 'published_post' => $post->ID], admin_url('admin.php?page=revisionary-q')), 'edit-new-revision') ),
                 'update' => esc_html__('Update', 'revisionary'),
             ));
 

--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -1112,7 +1112,7 @@ function rvy_revision_delete() {
 		// before deleting the revision, note its status for redirect
 		wp_delete_post_revision( $revision_id );
 
-		if (!empty($_SERVER['HTTP_REFERER']) && strpos($_SERVER['HTTP_REFERER'], 'revisionary-archive')) {
+		if (!empty($_SERVER['HTTP_REFERER']) && strpos(esc_url_raw($_SERVER['HTTP_REFERER']), 'revisionary-archive')) {
 			$redirect = add_query_arg('deleted', '1', esc_url_raw($_SERVER['HTTP_REFERER']));
 		} else {
 			$redirect = "admin.php?page=revisionary-archive&origin_post={$revision->post_parent}&revision_status={$revision->post_mime_type}&deleted=1";

--- a/admin/revision-archive_rvy.php
+++ b/admin/revision-archive_rvy.php
@@ -80,10 +80,10 @@ if (rvy_get_option('revision_archive_deletion')) {
 			<span class="dashicons dashicons-backup"></span>
 			<?php
 			esc_html_e( 'Revision Archive', 'revisionary' );
-			echo $wp_list_table->filters_in_heading();
+			$wp_list_table->filters_in_heading();
 			?>
 		</h1>
-		<?php echo $wp_list_table->search_in_heading(); ?>
+		<?php $wp_list_table->search_in_heading(); ?>
 	</header>
 	<?php $wp_list_table->views(); ?>
 	<form method="get">

--- a/admin/revisions.php
+++ b/admin/revisions.php
@@ -56,7 +56,7 @@ if ( empty($revision_id) && ! $left && ! $right ) {
 		}
 
 		if (!empty($arr) && is_array($arr) && !empty($arr['description'])) {
-			echo $arr['description'];
+			echo esc_html($arr['description']);
 		} else {
 			esc_html_e( 'Revision of this post is not allowed.', 'revisionary');
 		}
@@ -133,7 +133,7 @@ default :
 	<h1>
 	<?php printf(
 			esc_html__('Revisions of %s', 'revisionary'), 
-			"<a href='post.php?action=edit&post=$rvy_post->ID'>" . esc_html($rvy_post->post_title) . "</a>"
+			"<a href='post.php?action=edit&post=" . esc_attr($rvy_post->ID) . "'>" . esc_html($rvy_post->post_title) . "</a>"
 		);
 	?>
 	</h1>
@@ -144,7 +144,7 @@ default :
 
 	if ( $revision ) {
 		$left = $revision_id;
-		$post_title = "<a href='post.php?action=edit&post=$rvy_post->ID'>$rvy_post->post_title</a>";
+		$post_title = "<a href='post.php?action=edit&post=" . esc_attr($rvy_post->ID) . "'>" . esc_html($rvy_post->post_title) . "</a>";
 	} else {
 		$revision = $rvy_post;	
 	}
@@ -247,11 +247,11 @@ foreach ( array_keys($revision_status_captions) as $_revision_status ) {
 		if ($num_revisions->$_revision_status) {
 			echo "<li class='" . esc_attr($class) . "'><a href='" . esc_url($_link) . "' target='" . esc_attr($target) . "'>";
 			
-			$span_style = ('inherit' == $_revision_status) ? ' style="font-weight:bold"' : '';
+			$span_style = ('inherit' == $_revision_status) ? 'font-weight:bold' : '';
 
 			printf( 
 				esc_html__( '%1$s %2$s (%3$s)%4$s', 'revisionary' ), 
-				"<span class='count' $span_style>",
+				"<span class='count' style='" . esc_attr($span_style) . "'>",
 				esc_html($status_caption), 
 				esc_html(number_format_i18n( $num_revisions->$_revision_status )),
 				'</span>'

--- a/front_rvy.php
+++ b/front_rvy.php
@@ -370,13 +370,16 @@ class RevisionaryFront {
 				}
 			}
 		}
+	
+		if (empty($post) || !empty($_REQUEST['mark_current_revision'])) {	//phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			global $post;													//phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.VariableRedeclaration
+		}
 
 		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ((!empty($_REQUEST['mark_current_revision']) || rvy_in_revision_workflow($post) || ('revision' == $post->post_type)) && !isset($_REQUEST['fl_builder'])) {
 			add_filter('redirect_canonical', array($this, 'flt_revision_preview_url'), 10, 2);
 
 			if (!empty($_REQUEST['mark_current_revision'])) {										//phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				global $post;
 				$published_post_id = (!empty($post)) ? $post->ID : 0;
 				$revision_id = $published_post_id;
 			} else {
@@ -421,10 +424,6 @@ class RevisionaryFront {
 				}
 			}
 
-			if (empty($post)) {
-				global $post;
-			}
-			
 			if (empty($post)) {
 				return;
 			}
@@ -645,7 +644,6 @@ class RevisionaryFront {
 				if (defined('REVISIONARY_LEGACY_PREVIEW_OUTPUT')) {
 					add_action('wp_head', [$this, 'rvyFrontCSS']);
 				} else {
-					//add_action('wp_print_scripts', [$this, 'rvyFrontCSS'], 5);
 					add_action('wp_enqueue_scripts', [$this, 'rvyEnqueueStyle'], 50);
 				}
 

--- a/includes/CoreAdmin.php
+++ b/includes/CoreAdmin.php
@@ -6,7 +6,7 @@ class CoreAdmin {
         add_action('admin_print_scripts', [$this, 'setUpgradeMenuLink'], 50);
 
         add_action('publishpress_revisions_settings_sidebar', [$this, 'settingsSidebar']);
-        add_filter('publishpress_revisions_settings_sidebar', function($class) {return 'has-right-sidebar';});
+        add_filter('publishpress_revisions_settings_sidebar_class', function($class) {return 'has-right-sidebar';});
 
         add_filter(\PPVersionNotices\Module\TopNotice\Module::SETTINGS_FILTER, function ($settings) {
             $settings['revisionary'] = [
@@ -38,8 +38,8 @@ class CoreAdmin {
 
 		<script type="text/javascript">
             jQuery(document).ready(function($) {
-                $('#toplevel_page_revisionary-q ul li:last a').attr('href', '<?php echo $url;?>').attr('target', '_blank').css('font-weight', 'bold').css('color', '#FEB123');
-                $('#toplevel_page_revisionary-archive ul li:last a').attr('href', '<?php echo $url;?>').attr('target', '_blank').css('font-weight', 'bold').css('color', '#FEB123');
+                $('#toplevel_page_revisionary-q ul li:last a').attr('href', '<?php echo esc_url($url);?>').attr('target', '_blank').css('font-weight', 'bold').css('color', '#FEB123');
+                $('#toplevel_page_revisionary-archive ul li:last a').attr('href', '<?php echo esc_url($url);?>').attr('target', '_blank').css('font-weight', 'bold').css('color', '#FEB123');
             });
         </script>
 		<?php

--- a/lib/agapetry_wp_core_lib.php
+++ b/lib/agapetry_wp_core_lib.php
@@ -27,7 +27,7 @@ function agp_date_i18n( $datef, $timestamp ) {
 	if ( $timestamp >= 0 )
 		return date_i18n( $datef, $timestamp );
 	else
-		return date( $datef, $timestamp );
+		return gmdate( $datef, $timestamp );
 }
 }
 

--- a/revision-creation_rvy.php
+++ b/revision-creation_rvy.php
@@ -180,8 +180,8 @@ class RevisionCreation {
 
 		if ( $future_date = ! empty($data['post_date']) && ( strtotime($data['post_date_gmt'] ) > agp_time_gmt() ) ) {  // in past versions, $future_date was also passed to get_revision_msg()
 			// round down to zero seconds
-			$data['post_date_gmt'] = date( 'Y-m-d H:i:00', strtotime( $data['post_date_gmt'] ) );
-			$data['post_date'] = date( 'Y-m-d H:i:00', strtotime( $data['post_date'] ) );
+			$data['post_date_gmt'] = gmdate( 'Y-m-d H:i:00', strtotime( $data['post_date_gmt'] ) );
+			$data['post_date'] = gmdate( 'Y-m-d H:i:00', strtotime( $data['post_date'] ) );
 		}
 
 		// @todo: confirm this is still needed

--- a/revisionary.php
+++ b/revisionary.php
@@ -58,7 +58,7 @@ if (is_admin() && $invalid_php_version) {
                 echo '<div class="notice notice-error"><p>';
                 printf(
                     'PublishPress Revisions requires PHP version %s or higher.',
-                    $min_php_version
+                    esc_html($min_php_version)
                 );
                 echo '</p></div>';
             }
@@ -75,7 +75,7 @@ if (is_admin() && $invalid_wp_version) {
                 echo '<div class="notice notice-error"><p>';
                 printf(
                     'PublishPress Revisions requires WordPress version %s or higher.',
-                    $min_wp_version
+                    esc_html($min_wp_version)
                 );
                 echo '</p></div>';
             }

--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -645,7 +645,9 @@ class Revisionary
 	function act_new_revision_redirect() {
 		global $current_user, $post;
 
-		if (empty($_REQUEST['get_new_revision'])) {
+		if (!empty($_REQUEST['get_new_revision'])) {
+			check_admin_referer('new-revision');
+		} else {
 			return;
 		}
 
@@ -677,11 +679,13 @@ class Revisionary
 	function act_edit_revision_redirect() {
 		global $current_user, $post;
 
-		if (empty($_REQUEST['edit_new_revision'])) {
+		if (!empty($_REQUEST['edit_new_revision'])) {
+			check_admin_referer('edit-new-revision');
+		} else {
 			return;
 		}
 
-		$published_post_id = (!empty($_REQUEST['edit_new_revision'])) ? rvy_post_id($_REQUEST['edit_new_revision']) : rvy_post_id($post->ID);
+		$published_post_id = (!empty($_REQUEST['edit_new_revision'])) ? rvy_post_id((int) $_REQUEST['edit_new_revision']) : rvy_post_id($post->ID);
 		$published_url = get_permalink($published_post_id);
 
 		$revision = $this->get_last_revision($published_post_id, $current_user->ID);

--- a/rvy_init.php
+++ b/rvy_init.php
@@ -22,8 +22,8 @@ if (!defined('RVY_PREVIEW_ARG')) {
 }
 
 if (('preview' != RVY_PREVIEW_ARG) && !empty($_REQUEST['preview']) && !empty($_REQUEST['nc'])) {	// phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
-	$url = esc_url_raw($_SERVER['REQUEST_URI']);
-	$arr = parse_url(site_url());
+	$url = (isset($_SERVER['REQUEST_URI'])) ? esc_url_raw($_SERVER['REQUEST_URI']) : '';
+	$arr = wp_parse_url(site_url());
 	$url = $arr['scheme'] . '://' . $arr['host'] . $url;
 
 	$url = str_replace('preview=', RVY_PREVIEW_ARG . '=', $url);

--- a/utils.php
+++ b/utils.php
@@ -210,7 +210,6 @@ class Utils {
 		$conditions[] = $pluginsState['disable-gutenberg'] 
                         && !self::disableGutenberg(rvy_detect_post_id());
 
-		//if (defined('PP_CAPABILITIES_RESTORE_NAV_TYPE_BLOCK_EDITOR_DISABLE') && version_compare($wp_version, '5.9-beta', '>=')) {
         if (version_compare($wp_version, '5.9-beta', '>=') && !empty($has_nav_filter)) {
             add_filter('use_block_editor_for_post_type', '_disable_block_editor_for_navigation_post_type', 10, 2 );
         }


### PR DESCRIPTION
Improve wp-admin security by implementing some missing output variable escapes, sanitizations, and nonce checks. For easier security verification, refactor some code to directly output html rather than passing it as a variable. Replace date() and parse_url() calls with recommended WP equivalents. Also remove obsolete commented code.