### PR TITLE
Fixed escaped quote on 'revision you submitted' email message

### DIFF
--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -1387,6 +1387,7 @@ function rvy_publish_scheduled_revisions($args = []) {
 				if ( rvy_get_option( 'publish_scheduled_notify_revisor' ) ) {
 					$title = sprintf( esc_html__('[%s] %s Publication Notice', 'revisionary' ), $blogname, pp_revisions_status_label('future-revision', 'name') );
 					$message = sprintf( esc_html__('The scheduled revision you submitted for the %1$s "%2$s" has been published.', 'revisionary' ), $type_caption, $row->post_title ) . "\r\n\r\n";
+					$message = str_replace($message, '&quot;', '"', $message);
 
 					if ( ! empty($post->ID) )
 						$message .= esc_html__( 'View it online: ', 'revisionary' ) . $published_url . "\r\n";
@@ -1409,6 +1410,7 @@ function rvy_publish_scheduled_revisions($args = []) {
 				if ( ( ( $post->post_author != $row->post_author ) || defined( 'RVY_LEGACY_SCHEDULED_REV_POST_AUTHOR_NOTIFY' ) ) && rvy_get_option( 'publish_scheduled_notify_author' ) ) {
 					$title = sprintf( esc_html__('[%s] %s Publication Notice', 'revisionary' ), $blogname, pp_revisions_status_label('future-revision', 'name') );
 					$message = sprintf( esc_html__('A scheduled revision to your %1$s "%2$s" has been published.', 'revisionary' ), $type_caption, $post->post_title ) . "\r\n\r\n";
+					$message = str_replace($message, '&quot;', '"', $message);
 
 					if ( $revisor = new WP_User( $row->post_author ) )
 						$message .= sprintf( esc_html__('It was submitted by %1$s.'), $revisor->display_name ) . "\r\n\r\n";
@@ -1471,7 +1473,8 @@ function rvy_publish_scheduled_revisions($args = []) {
 						$title = sprintf(esc_html__('[%s] %s Publication'), $blogname, pp_revisions_status_label('future-revision', 'name') );
 						
 						$message = sprintf( esc_html__('A scheduled revision to the %1$s "%2$s" has been published.'), $type_caption, $row->post_title ) . "\r\n\r\n";
-	
+						$message = str_replace($message, '&quot;', '"', $message);
+
 						if ( $author = new WP_User( $row->post_author ) )
 							$message .= sprintf( esc_html__('It was submitted by %1$s.'), $author->display_name ) . "\r\n\r\n";
 	

--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -529,6 +529,7 @@ function rvy_revision_approve($revision_id = 0, $args = []) {
 			if (($db_action || !empty($args['force_notify'])) && rvy_get_option( 'rev_approval_notify_revisor' ) ) {
 				$title = sprintf(esc_html__('[%s] Revision Approval Notice', 'revisionary' ), $blogname );
 				$message = sprintf( esc_html__('The revision you submitted for the %1$s "%2$s" has been approved.', 'revisionary' ), $type_caption, $revision->post_title ) . "\r\n\r\n";
+				$message = str_replace($message, '&quot;', '"', $message);
 
 				if ( $scheduled ) {
 					$datef = __awp( 'M j, Y @ g:i a' );


### PR DESCRIPTION
The "A revision to the..." email message is being run through `esc_html()`, then the escaped double-quote is being converted back to plain text here: https://github.com/publishpress/PublishPress-Revisions/blob/master/admin/revision-action_rvy.php#L445

However, the "The revision you submitted for the..." email message is being escaped, but the escaped quote is not being converted back to plain text here: https://github.com/publishpress/PublishPress-Revisions/blob/master/admin/revision-action_rvy.php#L531

Example: 
![image](https://github.com/user-attachments/assets/1f39abb5-ba6e-43aa-9a51-1afa57af1045)

This PR fixes this formatting issue, and I also saw the same thing happening in a few other spots in `revision-action_rvy.php` 
