### PR TITLE
Fixed bug where suppress_redirects in createRevision() was getting wiped out by notification args

### DIFF
--- a/revision-creation_rvy.php
+++ b/revision-creation_rvy.php
@@ -125,8 +125,8 @@ class RevisionCreation {
 			require_once( dirname(REVISIONARY_FILE).'/revision-workflow_rvy.php' );
 			$rvy_workflow_ui = new \Rvy_Revision_Workflow_UI();
 
-			$args = ['revision_id' => $revision_id, 'published_post' => $published_post, 'object_type' => $published_post->post_type];
-			$rvy_workflow_ui->do_notifications('pending-revision', 'pending-revision', (array) $published_post, $args );
+			$notification_args = ['revision_id' => $revision_id, 'published_post' => $published_post, 'object_type' => $published_post->post_type];
+			$rvy_workflow_ui->do_notifications('pending-revision', 'pending-revision', (array) $published_post, $notification_args );
 		}
 
 		$url = apply_filters('revisionary_create_revision_redirect', rvy_admin_url("post.php?post=$revision_id&action=edit"), $revision_id);


### PR DESCRIPTION
This line in this commit https://github.com/publishpress/PublishPress-Revisions/commit/75312813977cd5a9d6c4d35a8ec68692642032a0#diff-73ebcea7fad6589b374b0fb2c059c7d536295c87c166d3ee7fe86cdf00d04f75R127 is resetting the `$args` variable.

If `suppress_redirect` was passed in the original array, it's being lost here and a redirect is happening when it should not.
