### PR TITLE
Reorganize plugin settings UI

### DIFF
--- a/admin/options.php
+++ b/admin/options.php
@@ -69,7 +69,7 @@ class RvyOptionUI {
 			echo "</label>";
 
 			if ( $hint_text && $this->display_hints )
-				echo "<div class='rs-subtext'>" . esc_html($hint_text) . "</div>";
+				echo "<div class='rvy-subtext'>" . esc_html($hint_text) . "</div>";
 
 			if ( ! empty($args['subcaption']) )
 				echo $args['subcaption'];		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -112,13 +112,12 @@ $this->tab_captions = array( 'features' => esc_html__( 'Settings', 'revisionary'
 $this->section_captions = array(
 	'features' => array(
 		'post_types'			=> esc_html__('Post Types', 'revisionary'),
-		'role_definition' 	  	=> esc_html__('Revisors', 'revisionary'),
 		'revision_statuses'		=> esc_html__('Statuses', 'revisionary'),
-		'working_copy'			=> rvy_get_option('revision_statuses_noun_labels') ? pp_revisions_status_label('draft-revision', 'plural') : esc_html__('Revision Creation', 'revisionary'),
-		'pending_revisions'		=> rvy_get_option('revision_statuses_noun_labels') ? pp_revisions_status_label('pending-revision', 'plural') : esc_html__('Revision Submission', 'revisionary'),
-		'scheduled_revisions' 	=> pp_revisions_status_label('future-revision', 'plural'),
+		'working_copy'			=> esc_html__('Revision Creation', 'revisionary'),
+		'pending_revisions'		=> esc_html__('Submission', 'revisionary'),
+		'scheduled_revisions' 	=> esc_html__('Scheduling', 'revisionary'),
 		'revision_queue'		=> esc_html__('Queue', 'revisionary'),
-		'preview'				=> esc_html__('Preview / Approval', 'revisionary'),
+		'preview'				=> esc_html__('Preview', 'revisionary'),
 		'revisions'				=> esc_html__('Options', 'revisionary'),
 		'notification'			=> esc_html__('Notifications', 'revisionary')
 	)
@@ -126,7 +125,7 @@ $this->section_captions = array(
 
 // TODO: replace individual _e calls with these (and section, tab captions)
 $pending_revision_singular = pp_revisions_status_label('pending-revision', 'name');
-$pending_revision_plural = rvy_get_option('revision_statuses_noun_labels') ? pp_revisions_status_label('pending-revision', 'plural') : esc_html__('Revision Submission', 'revisionary');
+$pending_revision_plural = rvy_get_option('revision_statuses_noun_labels') ? pp_revisions_status_label('pending-revision', 'plural') : esc_html__('Submission', 'revisionary');
 $pending_revision_basic = pp_revisions_status_label('pending-revision', 'basic');
 $future_revision_singular = pp_revisions_status_label('future-revision', 'name');
 
@@ -149,8 +148,8 @@ $this->option_captions = apply_filters('revisionary_option_captions',
 	'revisor_hide_others_revisions' => 			esc_html__("Listing others' revisions requires role capability", 'revisionary'),
 	'admin_revisions_to_own_posts' =>			esc_html__("Users can always administer revisions to their own editable posts", 'revisionary'),
 	'revision_update_notifications' =>			esc_html__('Also notify on Revision Update', 'revisionary'),
-	'trigger_post_update_actions' => 			esc_html__('Revision Publication: API actions to mimic Post Update', 'revisionary'),
-	'diff_display_strip_tags' => 				esc_html__('Hide html tags on Compare Revisions screen', 'revisionary'),
+	'trigger_post_update_actions' => 			esc_html__('Apply API actions to mimic Post Update', 'revisionary'),
+	'diff_display_strip_tags' => 				esc_html__('Hide html tags on Compare screen', 'revisionary'),
 	'scheduled_publish_cron' =>					esc_html__('Use WP-Cron scheduling', 'revisionary'),
 	'wp_cron_usage_detected' =>					esc_html__('Site uses a custom trigger for WP-Cron tasks', 'revisionary'),
 	'async_scheduled_publish' => 				esc_html__('Asynchronous Publishing', 'revisionary'),
@@ -173,15 +172,15 @@ $this->option_captions = apply_filters('revisionary_option_captions',
 	'preview_link_alternate_preview_arg' =>		esc_html__('Modify preview link for better theme compatibility', 'revisionary'),
 	'block_editor_extra_preview_button' =>		esc_html__('Extra preview button in Gutenberg Editor top bar', 'revisionary'),
 	'home_preview_set_home_flag' =>				esc_html__('Theme Compat: For front page revision preview, set home flag', 'revisionary'),
-	'compare_revisions_direct_approval' => 		esc_html__('Approve Button on Compare Revisions screen', 'revisionary'),
+	'compare_revisions_direct_approval' => 		esc_html__('Approve Button on Compare screen', 'revisionary'),
 	'copy_revision_comments_to_post' => 		esc_html__('Copy revision comments to published post', 'revisionary'),
-	'past_revisions_order_by' =>				esc_html__('Compare Past Revisions ordering:', 'revisionary'), 
+	'past_revisions_order_by' =>				esc_html__('Past Revisions ordering:', 'revisionary'), 
 	'list_unsubmitted_revisions' => 			sprintf(esc_html__('Include %s in My Activity, Revisions to My Posts views', 'revisionary'), pp_revisions_status_label('draft-revision', 'plural')),
-	'archive_postmeta' =>						esc_html__('On Revision publication, include custom fields in archive', 'revisionary'),
+	'archive_postmeta' =>						esc_html__('Store custom fields of submitted and scheduled revisions for archive', 'revisionary'),
 	'rev_publication_delete_ed_comments' =>		esc_html__('On Revision publication, delete Editorial Comments', 'revisionary'),
 	'deletion_queue' => 						esc_html__('Enable deletion queue', 'revisionary'),
-	'revision_archive_deletion' => 				esc_html__('Enable deletion in Revision Archive', 'revisionary'),
-	'revision_restore_require_cap' =>			esc_html__('Revision Restore: Non-Administrators need capability', 'revisionary'),
+	'revision_archive_deletion' => 				esc_html__('Enable deletion in archive', 'revisionary'),
+	'revision_restore_require_cap' =>			esc_html__('Additional role capability required to restore a revision', 'revisionary'),
 	'permissions_compat_mode' => 				esc_html__('Compatibility Mode', 'revisionary'),
 	'planner_notifications_access_limited' =>	esc_html__('Planner Notifications Access-Limited', 'revisionary'),
 	]
@@ -202,15 +201,14 @@ if ( defined('RVY_CONTENT_ROLES') ) {
 $this->form_options = apply_filters('revisionary_option_sections', [
 'features' => [
 	'license' =>			 ['edd_key'],
-	'post_types' =>			 ['enabled_post_types'],
-	'role_definition' => 	 ['revisor_role_add_custom_rolecaps', 'require_edit_others_drafts'],
-	'revision_statuses' =>	 ['revision_statuses_noun_labels'],
-	'working_copy' =>		 ['manage_unsubmitted_capability', 'copy_posts_capability', 'revision_limit_per_post', 'revision_limit_compat_mode', 'revision_unfiltered_html_check', 'auto_submit_revisions', 'caption_copy_as_edit'],
+	'post_types' =>			 ['revisor_role_add_custom_rolecaps', 'enabled_post_types'],
+	'revision_statuses' =>	 ['revision_statuses_noun_labels', 'permissions_compat_mode'],
+	'working_copy' =>		 ['copy_posts_capability', 'revision_limit_per_post', 'revision_limit_compat_mode', 'revision_unfiltered_html_check', 'auto_submit_revisions', 'caption_copy_as_edit'],
 	'scheduled_revisions' => ['scheduled_revisions', 'scheduled_publish_cron', 'async_scheduled_publish', 'wp_cron_usage_detected', 'scheduled_revision_update_post_date', 'scheduled_revision_update_modified_date'],
 	'pending_revisions'	=> 	 ['pending_revisions', 'revise_posts_capability', 'pending_revision_update_post_date', 'pending_revision_update_modified_date'],
-	'revision_queue' =>		 ['revisor_lock_others_revisions', 'revisor_hide_others_revisions', 'admin_revisions_to_own_posts', 'list_unsubmitted_revisions'],
-	'preview' =>			 ['revision_preview_links', 'preview_link_type', 'preview_link_alternate_preview_arg', 'home_preview_set_home_flag', 'compare_revisions_direct_approval', 'block_editor_extra_preview_button'],
-	'revisions'		=>		 ['trigger_post_update_actions', 'copy_revision_comments_to_post', 'diff_display_strip_tags', 'past_revisions_order_by', 'archive_postmeta', 'rev_publication_delete_ed_comments', 'permissions_compat_mode', 'deletion_queue', 'revision_archive_deletion', 'revision_restore_require_cap', 'display_hints'],
+	'revision_queue' =>		 ['manage_unsubmitted_capability', 'revisor_lock_others_revisions', 'revisor_hide_others_revisions', 'admin_revisions_to_own_posts', 'list_unsubmitted_revisions', 'deletion_queue'],
+	'preview' =>			 ['revision_preview_links', 'preview_link_type', 'preview_link_alternate_preview_arg', 'home_preview_set_home_flag', 'block_editor_extra_preview_button', 'compare_revisions_direct_approval', 'diff_display_strip_tags', 'past_revisions_order_by'],
+	'revisions'		=>		 ['require_edit_others_drafts', 'trigger_post_update_actions', 'copy_revision_comments_to_post', 'archive_postmeta', 'rev_publication_delete_ed_comments', 'revision_archive_deletion', 'revision_restore_require_cap', 'display_hints'],
 	'notification'	=>		 ['use_publishpress_notifications', 'planner_notifications_access_limited', 'pending_rev_notify_admin', 'pending_rev_notify_author', 'revision_update_notifications', 'rev_approval_notify_admin', 'rev_approval_notify_author', 'rev_approval_notify_revisor', 'publish_scheduled_notify_admin', 'publish_scheduled_notify_author', 'publish_scheduled_notify_revisor', 'use_notification_buffer'],
 ]
 ]);
@@ -422,12 +420,18 @@ if ( rvy_get_option('display_hints', $sitewide, $customize_defaults) ) {
 		<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 		<?php
+		$hint = esc_html__('The user role "Revisor" role is now available. Include capabilities for all custom post types in this role?', 'revisionary');
+		$this->option_checkbox( 'revisor_role_add_custom_rolecaps', $tab, $section, $hint, '' );
+		?>
+
+		<?php
 		$option_name = 'enabled_post_types';
 
 		$this->all_options []= $option_name;
 
+		echo '<br />';
 		esc_html_e('Enable revision submission for these Post Types:', 'revisionary');
-        echo '<br /><br />';
+        echo '<br />';
 
 		$hidden_types = ['attachment' => true, 'tablepress_table' => true, 'acf-field-group' => true, 'acf-field' => true, 'nav_menu_item' => true, 'custom_css' => true, 'customize_changeset' => true, 'wp_block' => true, 'wp_template' => true, 'wp_template_part' => true, 'wp_global_styles' => true, 'wp_navigation' => true];
 		$locked_types = [];
@@ -484,7 +488,7 @@ if ( rvy_get_option('display_hints', $sitewide, $customize_defaults) ) {
 		?>
 
 	<br />
-	<div class="rs-subtext">
+	<div class="rvy-subtext">
 	<?php
 	esc_html_e('Note: Third party code may cause some post types to be incompatible with PublishPress Revisions.', 'revisionary');
 	?>
@@ -494,34 +498,52 @@ if ( rvy_get_option('display_hints', $sitewide, $customize_defaults) ) {
 	<?php endif; // any options accessable in this section
 
 
-	$section = 'role_definition';			// --- ROLE DEFINITION SECTION ---
-
-	if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
-		<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
-
-		<?php
-		$hint = esc_html__('The user role "Revisor" role is now available. Include capabilities for all custom post types in this role?', 'revisionary');
-		$this->option_checkbox( 'revisor_role_add_custom_rolecaps', $tab, $section, $hint, '' );
-		?>
-
-		<?php
-		$hint = esc_html__('If checked, the edit_others_drafts capability will be required for users lacking site-wide publishing capabilities', 'revisionary');
-		$this->option_checkbox( 'require_edit_others_drafts', $tab, $section, $hint, '' );
-		?>
-
-	</td></tr></table>
-	<?php endif; // any options accessable in this section
-
-
-
 $section = 'revision_statuses';			// --- REVISION STATUSES SECTION ---
 
 if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 	<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 	<?php
+		if (!defined('PUBLISHPRESS_STATUSES_PRO_VERSION')) :
+		?>
+		<div id="revisions-pro-descript" class="activating" style="margin-bottom: 20px">
+		<?php
+		printf(
+			esc_html__('For custom Revision statuses and enhanced notifications, install %sPublishPress Statuses Pro%s.', 'revisionary'),
+			'<a href="https://publishpress.com/statuses/" target="_blank">',
+			'</a>'
+		);
+		?>
+		</div>
+		<?php endif;
+
 		$hint = esc_html__('Default labels are "Not Submitted for Approval", "Submitted for Approval", "Scheduled Revision"', 'revisionary');
 		$this->option_checkbox( 'revision_statuses_noun_labels', $tab, $section, $hint, '' );
+
+		echo "<br />";
+
+		$id = 'permissions_compat_mode';
+
+		$this->register_option($id);
+		$current_setting = rvy_get_option($id, $sitewide, $customize_defaults);
+
+		echo esc_html($this->option_captions[$id]);
+
+		$standard_caption = (defined('PUBLISHPRESS_REVISIONS_PRO_VERSION'))
+		? esc_html__('Broadest compat including Elementor, Divi, Beaver Builder', 'revisionary')
+		: esc_html__('Standard storage schema for broadest 3rd party compat', 'revisionary');
+
+		echo " <select name='" . esc_attr($id) . "' id='" . esc_attr($id) . "' autocomplete='off'>";
+		$captions = [
+			'' => $standard_caption, 
+			1 => esc_html__('Enhanced Revision access control with PublishPress plugins', 'revisionary'),
+		];
+
+		foreach ( $captions as $key => $value) {
+			$selected = ( $current_setting == $key ) ? 'selected' : '';
+			echo "\n\t<option value='" . esc_attr($key) . "' " . esc_attr($selected) . ">" . esc_html($captions[$key]) . "</option>";
+		}
+		echo '</select>&nbsp;';
 	?>
 
 </td></tr></table>
@@ -534,31 +556,12 @@ if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 	<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 	<?php
-	$hint = esc_html__('This restriction applies to users who are not full editors for the post type. To enable a role, add capabilities: copy_posts, copy_others_pages, etc.', 'revisionary');
-	$this->option_checkbox( 'copy_posts_capability', $tab, $section, $hint, '' );
-
-	if (defined('PRESSPERMIT_VERSION')) :?>
-		<div class="rs-subtext">
-		<?php esc_html_e('To expand the Posts / Pages listing for non-Editors, add capabilities: list_others_pages, list_published_posts, etc.', 'revisionary'); ?>
-		</div><br />
-	<?php endif;
-
-	$hint = esc_html__('To enable a role, add the manage_unsubmitted_revisions capability', 'revisionary');
-	$this->option_checkbox('manage_unsubmitted_capability', $tab, $section, $hint, '');
-
-	?>
-	<br />
-	<?php
 	$this->option_checkbox( 'revision_limit_per_post', $tab, $section, '', '' );
 
-	?>
-	<br />
-	<?php
 	$hide = empty(rvy_get_option('revision_limit_per_post'));
 	$hint = esc_html__('Work around cache plugin conflicts by requerying for revisions before suppressing the New Revision link.', 'revisionary');
 	$this->option_checkbox( 'revision_limit_compat_mode', $tab, $section, $hint, '', compact('hide') );
 	?>
-
 	<script type="text/javascript">
 	/* <![CDATA[ */
 	jQuery(document).ready( function($) {
@@ -569,22 +572,26 @@ if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 	/* ]]> */
 	</script>
 
-	<br />
 	<?php
+	$hint = sprintf(esc_html__('If the user does not have a regular Edit link, recaption the %s link as "Edit"', 'revisionary'), pp_revisions_status_label('draft-revision', 'submit_short'));
+	$this->option_checkbox( 'caption_copy_as_edit', $tab, $section, $hint, '' );
+
+	$hint = esc_html__('This restriction applies to users who are not full editors for the post type. To enable a role, add capabilities: copy_posts, copy_others_pages, etc.', 'revisionary');
+	
+	if (defined('PRESSPERMIT_VERSION')) {
+		$hint .= ' ' . esc_html__('To expand the Posts / Pages listing for non-Editors, add capabilities: list_others_pages, list_published_posts, etc.', 'revisionary');
+	}
+	
+	$this->option_checkbox( 'copy_posts_capability', $tab, $section, $hint, '' );
+
 	$hint = esc_html__('If disabled, revision by a user who does not have the unfiltered_html capability will cause all custom html tags to be stripped out.', 'revisionary');
 	$this->option_checkbox( 'revision_unfiltered_html_check', $tab, $section, $hint, '' );
 	?>
 
-	<br />
 	<?php
 	$this->option_checkbox( 'auto_submit_revisions', $tab, $section, '', '' );
 
 	do_action('revisionary_auto_submit_setting_ui', $this, $tab, $section);
-	?>
-	<br />
-	<?php
-	$hint = sprintf(esc_html__('If the user does not have a regular Edit link, recaption the %s link as "Edit"', 'revisionary'), pp_revisions_status_label('draft-revision', 'submit_short'));
-	$this->option_checkbox( 'caption_copy_as_edit', $tab, $section, $hint, '' );
 	?>
 	</td></tr></table>
 <?php endif; // any options accessable in this section
@@ -603,7 +610,7 @@ $pending_revisions_available ) :
 		<?php
 		$this->option_checkbox('pending_revisions', $tab, $section, '', '', ['style' => 'margin-bottom: 0']);
 
-		echo "<div class='rs-subtext' style='margin-bottom: 8px'>"
+		echo "<div class='rvy-subtext'>"
 		. sprintf(
 			esc_html__( 'Enable published content to be copied, edited, submitted for approval and managed in %sRevision Queue%s.', 'revisionary' ),
 			"<a href='" . esc_url(rvy_admin_url('admin.php?page=revisionary-q')) . "'>",
@@ -672,6 +679,9 @@ if ( 	// To avoid confusion, don't display any revision settings if pending revi
 			<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 			<?php
+			$hint = esc_html__('To enable a role, add the manage_unsubmitted_revisions capability', 'revisionary');
+			$this->option_checkbox('manage_unsubmitted_capability', $tab, $section, $hint, '');
+	
 			$hint = esc_html__('This restriction applies to users who are not full editors for the post type. To enable a role, give it the edit_others_revisions capability.', 'revisionary');
 			$this->option_checkbox( 'revisor_lock_others_revisions', $tab, $section, $hint, '' );
 
@@ -683,6 +693,8 @@ if ( 	// To avoid confusion, don't display any revision settings if pending revi
 
 			$hint = '';
 			$this->option_checkbox( 'list_unsubmitted_revisions', $tab, $section, $hint, '' );
+
+			do_action('revisionary_option_ui_revision_queue_options', $this, $sitewide, $customize_defaults);
 		?>
 
 		<?php if (!empty($_SERVER['REQUEST_URI'])):?>
@@ -702,28 +714,39 @@ if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 	<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 	<?php
-	$hint = esc_html__('For themes that block revision preview, hide preview links from non-Administrators.', 'revisionary');
+	$hint = esc_html__('Some themes may block revision preview.', 'revisionary');
 	$this->option_checkbox( 'revision_preview_links', $tab, $section, $hint, '' );
+
+	$preview_links = rvy_get_option('revision_preview_links');
 
 	$id = 'preview_link_type';
 	if ( in_array( $id, $this->form_options[$tab][$section] ) ) {
 		$this->all_options []= $id;
 		$current_setting = rvy_get_option($id, $sitewide, $customize_defaults);
+		?>
+		<div id="rvy_preview_options" style="padding-left: 25px;<?php if (!$preview_links) echo 'display: none;';?>">
+		<label for="<?php echo esc_attr($id);?>"><?php echo esc_html($this->option_captions[$id]);?>: </label>
 
-		echo '<div style="padding-left: 25px">';
-		echo "<label for='" . esc_attr($id) . "'>" . esc_html($this->option_captions[$id]) . ': </label>';
+		<select name="<?php echo esc_attr($id);?>" id="<?php echo esc_attr($id);?>" autocomplete="off">
 
-		echo " <select name='" . esc_attr($id) . "' id='" . esc_attr($id) . "' autocomplete='off'>";
-		$captions = array( '' => esc_html__('Published Post Slug', 'revisionary'), 'revision_slug' => esc_html__('Revision Slug', 'revisionary'), 'id_only' => esc_html__('Revision ID only', 'revisionary') );
+		<?php
+		$captions = [
+			'' => esc_html__('Published Post Slug', 'revisionary'), 
+			'revision_slug' => esc_html__('Revision Slug', 'revisionary'), 
+			'id_only' => esc_html__('Revision ID only', 'revisionary') 
+		];
+
 		foreach ( $captions as $key => $value) {
 			$selected = ( $current_setting == $key ) ? 'selected' : '';
 			echo "\n\t<option value='" . esc_attr($key) . "' " . esc_attr($selected) . ">" . esc_html($captions[$key]) . "</option>";
 		}
-		echo '</select>&nbsp;';
+		?>
+		</select>&nbsp;
 
+		<?php
 		if ( $this->display_hints ) : ?>
 			<br />
-			<div class="rs-subtext">
+			<div class="rvy-subtext">
 			<?php
 			esc_html_e('Some themes or plugins may require Revision Slug or Revision ID link type for proper template loading and field display.', 'revisionary');
 			?>
@@ -732,8 +755,6 @@ if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 
 		do_action('revisionary_option_ui_preview_options', $this, $sitewide, $customize_defaults);
 
-		echo '<br />';
-		
 		if (defined('RVY_PREVIEW_ARG_LOCKED') && defined('RVY_PREVIEW_ARG')) {
 			printf(
 				esc_html__(
@@ -746,26 +767,52 @@ if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 			$hint = esc_html__('Adjust preview links to use "rv_preview" argument instead of "preview". Experiment to see which works best with your theme.', 'revisionary');
 			$this->option_checkbox( 'preview_link_alternate_preview_arg', $tab, $section, $hint, '' );
 		}
+
+		$hint = esc_html__('Some themes may require this setting for correct revision preview display.', 'revisionary');
+		$this->option_checkbox( 'home_preview_set_home_flag', $tab, $section, $hint, '' );
+
+		$hint = '';
+		$this->option_checkbox( 'block_editor_extra_preview_button', $tab, $section, $hint, '' );
 		?>
 		</div>
-		<br />
+		
+		<script type="text/javascript">
+		/* <![CDATA[ */
+		jQuery(document).ready( function($) {
+			$('#revision_preview_links').on('click', function(e) {
+				$('#rvy_preview_options').toggle($(e).prop('checked'));
+			});
+		});
+		/* ]]> */
+		</script>
 		<?php
 	}
 
-	$hint = esc_html__('Some themes may require this setting for correct revision preview display.', 'revisionary');
-	$this->option_checkbox( 'home_preview_set_home_flag', $tab, $section, $hint, '' );
-	?>
-	<br />
+	echo '<h4 style="margin-top: 30px; margin-bottom:8px">' . esc_html__('Compare Revisions:', 'revisionary-pro') . '</h4>';
 
-	<?php
+	$id = 'past_revisions_order_by';
+	if ( in_array( $id, $this->form_options[$tab][$section] ) ) {
+		echo esc_html($this->option_captions[$id]);
+
+		$this->all_options []= $id;
+		$current_setting = rvy_get_option($id, $sitewide, $customize_defaults);
+
+		echo " <select name='" . esc_attr($id) . "' id='" . esc_attr($id) . "' autocomplete='off'>";
+		$captions = ['' => esc_html__('Post Date', 'revisionary'), 'modified' => esc_html__('Modification Date', 'revisionary')];
+		foreach ( $captions as $key => $value) {
+			$selected = ( $current_setting == $key ) ? 'selected' : '';
+			echo "\n\t<option value='" . esc_attr($key) . "' " . esc_attr($selected) . ">" . esc_html($captions[$key]) . "</option>";
+		}
+		echo '</select>&nbsp;';
+
+		echo "<br />";
+	}
+
+	$hint = '';
+	$this->option_checkbox( 'diff_display_strip_tags', $tab, $section, $hint, '' );
+
 	$hint = esc_html__('If disabled, Compare screen links to Revision Preview for approval.', 'revisionary');
 	$this->option_checkbox( 'compare_revisions_direct_approval', $tab, $section, $hint, '' );
-	?>
-	<br />
-
-	<?php
-	$hint = '';
-	$this->option_checkbox( 'block_editor_extra_preview_button', $tab, $section, $hint, '' );
 	?>
 	</td></tr></table>
 <?php endif; // any options accessable in this section
@@ -780,89 +827,25 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 		<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 		<?php
-		if (!defined('PUBLISHPRESS_REVISIONS_PRO_VERSION')) :
+		$hint = esc_html__('If checked, the edit_others_drafts capability will be required for users lacking site-wide publishing capabilities', 'revisionary');
+		$this->option_checkbox( 'require_edit_others_drafts', $tab, $section, $hint, '' );
 		?>
-		<div id="revisions-pro-descript" class="activating">
-		
-		<?php
-		printf(
-			esc_html__('For compatibility with Advanced Custom Fields, Beaver Builder and WPML, upgrade to %sPublishPress Revisions Pro%s.', 'revisionary'),
-			'<a href="https://publishpress.com/revisionary/" target="_blank">',
-			'</a>'
-		);
-		?>
-		
-		</div>
-		<?php endif;?>
 
 		<?php
-		$hint = esc_html__('This may improve compatibility with some plugins.', 'revisionary');
-		$this->option_checkbox( 'trigger_post_update_actions', $tab, $section, $hint, '' );
-
-		$hint = '';
-		$this->option_checkbox( 'copy_revision_comments_to_post', $tab, $section, $hint, '' );
-
-		$hint = '';
-		$this->option_checkbox( 'diff_display_strip_tags', $tab, $section, $hint, '' );
-
-		echo "<br />";
-
-		$id = 'past_revisions_order_by';
-		if ( in_array( $id, $this->form_options[$tab][$section] ) ) {
-			echo esc_html($this->option_captions[$id]);
-
-			$this->all_options []= $id;
-			$current_setting = rvy_get_option($id, $sitewide, $customize_defaults);
-
-			echo " <select name='" . esc_attr($id) . "' id='" . esc_attr($id) . "' autocomplete='off'>";
-			$captions = ['' => esc_html__('Post Date', 'revisionary'), 'modified' => esc_html__('Modification Date', 'revisionary')];
-			foreach ( $captions as $key => $value) {
-				$selected = ( $current_setting == $key ) ? 'selected' : '';
-				echo "\n\t<option value='" . esc_attr($key) . "' " . esc_attr($selected) . ">" . esc_html($captions[$key]) . "</option>";
-			}
-			echo '</select>&nbsp;';
-
-			echo "<br /><br />";
-		}
-
-		$hint = esc_html__( 'Show descriptive captions for PublishPress Revisions settings', 'revisionary' );
-		$this->option_checkbox( 'display_hints', $tab, $section, $hint, '' );
-
-		echo "<br />";
-		$this->option_checkbox( 'archive_postmeta', $tab, $section, '', '' );
+		echo '<h4 style="margin-top: 30px; margin-bottom:0">' . esc_html__('Revision Publication:', 'revisionary-pro') . '</h4>';
 
 		if (defined('PUBLISHPRESS_VERSION')) {
 			$this->option_checkbox( 'rev_publication_delete_ed_comments', $tab, $section, '', '' );
 		}
 
-		echo "<br />";
+		$this->option_checkbox( 'copy_revision_comments_to_post', $tab, $section, '', '' );
 
-		$id = 'permissions_compat_mode';
+		$hint = esc_html__('This may improve compatibility with some plugins.', 'revisionary');
+		$this->option_checkbox( 'trigger_post_update_actions', $tab, $section, $hint, '' );
 
-		$this->register_option($id);
-		$current_setting = rvy_get_option($id, $sitewide, $customize_defaults);
+		echo '<h4 style="margin-top: 30px; margin-bottom:0">' . esc_html__('Revision Archive:', 'revisionary-pro') . '</h4>';
 
-		echo esc_html($this->option_captions[$id]);
-
-		$standard_caption = (defined('PUBLISHPRESS_REVISIONS_PRO_VERSION'))
-		? esc_html__('Broadest compat including Elementor, Divi, Beaver Builder', 'revisionary')
-		: esc_html__('Standard storage schema for broadest 3rd party compat', 'revisionary');
-
-		echo " <select name='" . esc_attr($id) . "' id='" . esc_attr($id) . "' autocomplete='off'>";
-		$captions = [
-			'' => $standard_caption, 
-			1 => esc_html__('Enhanced Revision access control with PublishPress plugins', 'revisionary'),
-		];
-
-		foreach ( $captions as $key => $value) {
-			$selected = ( $current_setting == $key ) ? 'selected' : '';
-			echo "\n\t<option value='" . esc_attr($key) . "' " . esc_attr($selected) . ">" . esc_html($captions[$key]) . "</option>";
-		}
-		echo '</select>&nbsp;';
-
-		echo "<br />";
-
-		do_action('revisionary_option_ui_revision_options', $this, $sitewide, $customize_defaults);
+		$this->option_checkbox( 'archive_postmeta', $tab, $section, '', '' );
 
 		$hint = '';
 		$this->option_checkbox( 'revision_archive_deletion', $tab, $section, $hint, '' );
@@ -871,6 +854,13 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 			$hint = esc_html__('Non-Administrators cannot restore a revision without the restore_revisions capability', 'revisionary');
 			$this->option_checkbox( 'revision_restore_require_cap', $tab, $section, $hint, '' );
 		}
+
+		do_action('revisionary_option_ui_revision_options', $this, $sitewide, $customize_defaults);
+
+		echo "<br />";
+
+		$hint = esc_html__( 'Show descriptive captions for PublishPress Revisions settings', 'revisionary' );
+		$this->option_checkbox( 'display_hints', $tab, $section, $hint, '' );
 		?>
 
 		</td></tr></table>
@@ -883,6 +873,41 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 		<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 		<?php
+		if (!defined('PUBLISHPRESS_STATUSES_PRO_VERSION')) :
+			?>
+			<div id="revisions-pro-descript" class="activating" style="margin-bottom: 20px">
+			<?php
+			printf(
+				esc_html__('For enhanced notifications, install %sPublishPress Statuses Pro%s.', 'revisionary'),
+				'<a href="https://publishpress.com/statuses/" target="_blank">',
+				'</a>'
+			);
+			?>
+			</div>
+		<?php elseif (!defined('PUBLISHPRESS_VERSION')) :
+			?>
+			<div id="revisions-pro-descript" class="activating" style="margin-bottom: 20px">
+			<?php
+			printf(
+				esc_html__('For enhanced notifications, install %sPublishPress Planner%s.', 'revisionary'),
+				'<a href="' . admin_url('plugin-install.php?s=publishpress%2520planner&tab=search&type=term') . '" target="_blank">',
+				'</a>'
+			);
+			?>
+			</div>
+		<?php elseif (!version_compare(PUBLISHPRESS_VERSION, '4.6-beta', '>=')) :
+			?>
+			<div id="revisions-pro-descript" class="activating" style="margin-bottom: 20px">
+			<?php
+			printf(
+				esc_html__('For enhanced notifications, update %sPublishPress Planner%s.', 'revisionary'),
+				'<a href="' . admin_url('plugin-install.php?s=publishpress%2520planner&tab=search&type=term') . '" target="_blank">',
+				'</a>'
+			);
+			?>
+			</div>
+		<?php endif;
+
 		if (defined('PUBLISHPRESS_VERSION') && version_compare(PUBLISHPRESS_VERSION, '4.6-beta', '>=') && defined('PUBLISHPRESS_STATUSES_PRO_VERSION')) {
 			$hint = '';
 			$this->option_checkbox( 'use_publishpress_notifications', $tab, $section, $hint, '', ['no_escape' => true] );
@@ -1132,7 +1157,7 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 		?>
 		<a href="<?php echo esc_url($url);?>"><?php esc_html_e('Sync "Needs Update" flags', 'revisionary');?></a>
 
-		<div class="rs-subtext">
+		<div class="rvy-subtext">
 		<?php
 		esc_html_e('Set "Needs Update" for any post with translations which was updated (possibly by revision approval) more recently than its translations.', 'revisionary');
 		?>

--- a/admin/revisionary.css
+++ b/admin/revisionary.css
@@ -227,10 +227,11 @@ padding: 0;
 .rs-agents_list_29_5 li { width: 29.5em; }
 .rs-agents_list_30_5 li { width: 30.5em; }
 
-.rs-subtext {
+.rvy-subtext {
 color: #777;
 font-style:italic;
 margin-top:5px;
+margin-bottom:20px;
 }
 
 .rs-warning {


### PR DESCRIPTION
Clean up screen space by eliminating one tab and shortening the caption of others. Rearrange some settings and add a few grouping captions for more intuitive discovery and logical association.

Closes #1406