### PR TITLE
Revisors can't edit newly created revision if Authors and Permissions plugins both active

### DIFF
--- a/compat_rvy.php
+++ b/compat_rvy.php
@@ -59,6 +59,7 @@ class PP_Revisions_Compat {
         ) {
             self::jreviews_preview_compat();
         }
+        add_filter('presspermit_maybe_override_authors_change', [$this, 'fltPermissionsOverrideAuthorsChange'], 10, 2);
     }
 
     function fltRequireRevisionBaseStatuses($require_base_statuses) {
@@ -85,6 +86,13 @@ class PP_Revisions_Compat {
     function fltDefaultOptionScope($options) {
         $options['permissions_conmpat_mode'] = true;
         return $options;
+    }
+    function fltPermissionsOverrideAuthorsChange($maybe_override, $post) {
+        if (did_action('revisionary_pre_insert_revision')) {
+            $maybe_override_authors = false;
+        }
+
+        return $maybe_override_authors;
     }
 
     // JReviews plugin breaks Pending Revision / Scheduled Revision preview

--- a/revision-creation_rvy.php
+++ b/revision-creation_rvy.php
@@ -200,6 +200,8 @@ class RevisionCreation {
 		$data['guid'] = '';
 		$data['post_name'] = '';
 
+		do_action( 'revisionary_pre_insert_revision', $revision_id, $main_post_id, $data );
+
 		$revision_id = wp_insert_post(\wp_slash($data), true);
 
 		if (is_wp_error($revision_id)) {


### PR DESCRIPTION
Fixes #1461