### PR TITLE
Clear Plugin data upon deleting the plugin

### DIFF
--- a/admin/options.php
+++ b/admin/options.php
@@ -166,6 +166,7 @@ $this->option_captions = apply_filters('revisionary_option_captions',
 	'revisor_role_add_custom_rolecaps' => 		esc_html__('All custom post types available to Revisors', 'revisionary' ),
 	'require_edit_others_drafts' => 			esc_html__("Prevent Revisors from editing other user's drafts", 'revisionary' ),
 	'display_hints' => 							esc_html__('Display Hints', 'revisionary'),
+	'delete_settings_on_uninstall' => 			esc_html__('Delete settings and data if plugin is deleted', 'revisionary'),
 	'revision_preview_links' => 				esc_html__('Show Preview Links', 'revisionary'),
 	'preview_link_type' => 						esc_html__('Preview Link Type', 'revisionary'),
 	'preview_link_alternate_preview_arg' =>		esc_html__('Modify preview link for better theme compatibility', 'revisionary'),
@@ -205,7 +206,7 @@ $this->form_options = apply_filters('revisionary_option_sections', [
 	'pending_revisions'	=> 	 ['pending_revisions', 'revise_posts_capability', 'pending_revision_update_post_date', 'pending_revision_update_modified_date'],
 	'revision_queue' =>		 ['manage_unsubmitted_capability', 'revisor_lock_others_revisions', 'revisor_hide_others_revisions', 'admin_revisions_to_own_posts', 'list_unsubmitted_revisions', 'deletion_queue'],
 	'preview' =>			 ['revision_preview_links', 'preview_link_type', 'preview_link_alternate_preview_arg', 'home_preview_set_home_flag', 'block_editor_extra_preview_button', 'compare_revisions_direct_approval', 'diff_display_strip_tags', 'past_revisions_order_by'],
-	'revisions'		=>		 ['require_edit_others_drafts', 'trigger_post_update_actions', 'copy_revision_comments_to_post', 'archive_postmeta', 'rev_publication_delete_ed_comments', 'revision_archive_deletion', 'revision_restore_require_cap', 'revision_statuses_noun_labels', 'display_hints'],
+	'revisions'		=>		 ['require_edit_others_drafts', 'trigger_post_update_actions', 'copy_revision_comments_to_post', 'archive_postmeta', 'rev_publication_delete_ed_comments', 'revision_archive_deletion', 'revision_restore_require_cap', 'revision_statuses_noun_labels', 'display_hints', 'delete_settings_on_uninstall'],
 	'notification'	=>		 ['use_publishpress_notifications', 'planner_notifications_access_limited', 'pending_rev_notify_admin', 'pending_rev_notify_author', 'revision_update_notifications', 'rev_approval_notify_admin', 'rev_approval_notify_author', 'rev_approval_notify_revisor', 'publish_scheduled_notify_admin', 'publish_scheduled_notify_author', 'publish_scheduled_notify_revisor', 'use_notification_buffer'],
 	'license' =>			 ['edd_key'],
 ]
@@ -878,6 +879,9 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 
 		$hint = esc_html__( 'Show descriptive captions for PublishPress Revisions settings', 'revisionary' );
 		$this->option_checkbox( 'display_hints', $tab, $section, $hint, '' );
+
+		$hint = esc_html__('note: Plugin settings and configuration data will be deleted, but only after the last copy of Revisions / Revisions Pro is deleted.', 'revisionary');
+		$this->option_checkbox('delete_settings_on_uninstall', $tab, $section, $hint);
 		?>
 
 		</td></tr></table>

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,68 @@
+<?php
+if (get_option('rvy_delete_settings_on_uninstall')) {
+    global $wpdb;
+
+    // Since stored settings are shared among all installed versions, 
+    // all copies of the plugin (both Pro and Free) need to be deleted (not just deactivated) before deleting any settings.
+    $revisions_plugin_count = 0;
+
+    if ( ! function_exists( 'get_plugins' ) ) {
+        require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    }
+    
+    $_plugins = get_plugins();
+    
+    foreach($_plugins as $_plugin) {
+        if (!empty($_plugin['Title']) && in_array($_plugin['Title'], ['PublishPress Revisions', 'PublishPress Revisions Pro'])) {
+            $revisions_plugin_count++;
+        }
+    }
+    
+    if ($revisions_plugin_count === 1) {
+        $orig_site_id = get_current_blog_id();
+        
+        $site_ids = (function_exists('get_sites')) ? get_sites(['fields' => 'ids']) : (array) $orig_site_id;
+        
+        // phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+
+        foreach ($site_ids as $_blog_id) {
+            if (is_multisite()) {
+            	switch_to_blog($_blog_id);
+            }
+
+            if (!empty($wpdb->options)) {
+                @$wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE 'rvy_%'");
+                @$wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE '_rvy_%'");
+                @$wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE '%_rvy'");
+                @$wpdb->query("DELETE FROM $wpdb->options WHERE option_name LIKE '%revisionary_%'");
+            }
+
+            delete_option('revisionary_last_version');
+            delete_option('_pp_statuses_planner_default_revision_notifications');
+            delete_option('pp_revisions_beta3_option_sync_done');
+
+            wp_load_alloptions(true);
+            
+            if (!empty($wpdb->postmeta)) {
+                @$wpdb->query(
+                    "DELETE FROM $wpdb->postmeta WHERE meta_key IN ("
+                    . "'_rvy_revision_status', '_rvy_base_post_id', '_rvy_imported_revision', '_rvy_has_revisions', '_rvy_published_gmt', '_rvy_author_selection', '_rvy_prev_revision_status', '_rvy_approved_by', '_rvy_subpost_original_source_id', '_rvy_deletion_request_date'"
+                    . ")"
+                );
+            }
+
+            if ($revision_ids = $wpdb->get_col("SELECT COUNT(ID) FROM $wpdb->posts WHERE post_mime_type IN ('draft-revision', 'pending-revision', 'future-revision', 'revision-deferred', 'revision-needs-work', 'revision-rejected')")) {
+                $id_csv = implode("','", array_map('intval', $revision_ids));
+                
+                $wpdb->query("DELETE FROM $wpdb->posts WHERE ID IN ('$id_csv') AND post_mime_type IN ('draft-revision', 'pending-revision', 'future-revision', 'revision-deferred', 'revision-needs-work', 'revision-rejected')");   
+                $wpdb->query("DELETE FROM $wpdb->postmeta WHERE post_id IN ('$id_csv')");   
+                
+                wp_cache_flush();
+            }
+        }
+
+        if (is_multisite()) {
+        	switch_to_blog($orig_site_id);
+        }
+    }
+}


### PR DESCRIPTION
Closes #1156

Note that plugin settings and data will only be deleted if all copies of Revisions and Revisions Pro are deleted (not just deactivated)