### PR TITLE
Updating a post can cause post status to be cleared

### DIFF
--- a/activation_rvy.php
+++ b/activation_rvy.php
@@ -60,9 +60,13 @@ class RevisionaryActivation {
 
             // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
             $wpdb->insert($wpdb->posts, $new);
+
             $new_revision_id = (int)$wpdb->insert_id;
             
-            add_post_meta($new_revision_id, '_rvy_base_post_id', $new['comment_count']);
+            if ($new['comment_count'] != $new_revision_id) {
+                add_post_meta($new_revision_id, '_rvy_base_post_id', $new['comment_count']);
+            }
+
             add_post_meta($new_revision_id, '_rvy_imported_revision', $old->rev_ID);
 
             if ($new['comment_count'] != $last_post_id) {  // avoid redundant update for same post

--- a/admin/class-list-table_rvy.php
+++ b/admin/class-list-table_rvy.php
@@ -617,8 +617,10 @@ class Revisionary_List_Table extends WP_Posts_List_Table {
 		if ($revision_ids = $wpdb->get_col("SELECT ID FROM $wpdb->posts WHERE post_mime_type IN ('$revision_status_csv') AND comment_count = 0")) {
 			foreach($revision_ids as $revision_id) {
 				if ($main_post_id = get_post_meta($revision_id, '_rvy_base_post_id', true)) {
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-					$wpdb->update($wpdb->posts, ['comment_count' => $main_post_id], ['ID' => $revision_id]);
+					if ($main_post_id != $revision_id) {
+						// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+						$wpdb->update($wpdb->posts, ['comment_count' => $main_post_id], ['ID' => $revision_id]);
+					}
 				}
 			}
 		}

--- a/functions.php
+++ b/functions.php
@@ -4,14 +4,11 @@ function revisionary() {
 }
 
 function revisionary_unrevisioned_postmeta() {
-	$exclude = array_fill_keys( array( '_rvy_base_post_id', '_rvy_has_revisions', '_rvy_published_gmt', '_rvy_approved_by', '_pp_is_autodraft', '_pp_last_parent', '_edit_lock', '_edit_last', '_wp_old_slug', '_wp_attached_file', '_menu_item_classes', '_menu_item_menu_item_parent', '_menu_item_object', '_menu_item_object_id', '_menu_item_target', '_menu_item_type', '_menu_item_url', '_menu_item_xfn', '_rs_file_key', '_scoper_custom', '_scoper_last_parent', '_wp_attachment_backup_sizes', '_wp_attachment_metadata', '_wp_trash_meta_status', '_wp_trash_meta_time', '_last_attachment_ids', '_last_category_ids', '_encloseme', '_pingme', '_pp_statuses_last_main_status', 'peepso_postnotify', '_rvy_subpost_original_source_id' ), true );
-	$exclude = apply_filters( 'revisionary_unrevisioned_postmeta', $exclude );
+	$exclude = (array) apply_filters( 'revisionary_unrevisioned_postmeta', [] );
+
 	$exclude = array_merge(
 		$exclude, 
-		array_fill_keys(  // These cannot be revisioned without breaking plugin functionality
-			['_rvy_base_post_id', '_rvy_has_revisions', '_rvy_published_gmt', '_pp_is_autodraft'],
-			true
-		)
+		array_fill_keys(['_rvy_base_post_id',  '_rvy_has_revisions', '_rvy_published_gmt', '_rvy_approved_by', '_pp_is_autodraft', '_pp_last_parent', '_edit_lock', '_edit_last', '_wp_old_slug', '_wp_attached_file',			'_menu_item_classes', '_menu_item_menu_item_parent', '_menu_item_object', '_menu_item_object_id',			'_menu_item_target',		'_menu_item_type','_menu_item_url','_menu_item_xfn','_rs_file_key','_scoper_custom','_scoper_last_parent','_wp_attachment_backup_sizes','_wp_attachment_metadata','_wp_trash_meta_status','_wp_trash_meta_time','_last_attachment_ids','_last_category_ids','_encloseme','_pingme','_pp_statuses_last_main_status','peepso_postnotify','_peepso_postnotify','_rvy_subpost_original_source_id','jr_listing_views','_jr_listing_views'],true)
 	);
 	
 	return array_keys(array_filter($exclude));
@@ -304,7 +301,7 @@ function rvy_post_id($revision_id) {
                 $published_id = rvy_get_post_meta( $revision_id, '_rvy_base_post_id', true );
                 $busy = false;
 
-                if ($published_id) {
+                if ($published_id && ($published_id != $revision_id)) {
                     global $wpdb;
 
                     // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/revision-creation_rvy.php
+++ b/revision-creation_rvy.php
@@ -268,7 +268,9 @@ class RevisionCreation {
 			revisionary_copy_postmeta($base_post_id, $revision_id);
 		}
 
-		rvy_update_post_meta($revision_id, '_rvy_base_post_id', $base_post_id);
+		if ($base_post_id != $revision_id) {
+			rvy_update_post_meta($revision_id, '_rvy_base_post_id', $base_post_id);
+		}
 
 		if (!defined('REVISIONARY_LIMIT_IGNORE_UNSUBMITTED')) {
 			rvy_update_post_meta($base_post_id, '_rvy_has_revisions', true);

--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -624,8 +624,10 @@ class Revisionary
 		if (rvy_in_revision_workflow($revision)) {
 			if (empty($revision->comment_count)) {
 				if ($main_post_id = get_post_meta($revision->ID, '_rvy_base_post_id', true)) {
-					// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-					$wpdb->update($wpdb->posts, ['comment_count' => $main_post_id], ['ID' => $revision->ID]);
+					if ($main_post_id != $revision->ID) {
+						// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+						$wpdb->update($wpdb->posts, ['comment_count' => $main_post_id], ['ID' => $revision->ID]);
+					}
 				}
 			}
 		}
@@ -1238,7 +1240,9 @@ class Revisionary
 			// Revisions are not published by wp_update_post() execution; Prevent setting to a non-revision status
 			// @todo: confirm this is still needed
 
-			if (rvy_get_post_meta($postarr['ID'], '_rvy_base_post_id', true) 
+			$base_post_id = rvy_get_post_meta($postarr['ID'], '_rvy_base_post_id', true);
+
+			if (($base_post_id && ($base_post_id != $postarr['ID']))
 			&& ('trash' != $data['post_status'])
 			) {
 				if (!$revision = get_post($postarr['ID'])) {
@@ -1274,7 +1278,7 @@ class Revisionary
 					}
 				}
 
-				if (rvy_get_option('permissions_compat_mode') && ('revision' != $data['post_type'])) {
+				if (rvy_get_option('permissions_compat_mode') && ('revision' != $data['post_type']) && rvy_is_revision_status($data['post_mime_type'])) {
 					$data['post_status'] = $data['post_mime_type'];
 				}
 			}


### PR DESCRIPTION
Fixes #1508

Prevent a post from being incorrectly treated as a Revision.