### PR TITLE
PHP Notice in WP 6.8 if another plugin calls wp_schedule_event() too early

### DIFF
--- a/rvy_init-functions.php
+++ b/rvy_init-functions.php
@@ -74,8 +74,12 @@ function rvy_set_notification_buffer_cron() {
 function rvy_mail_buffer_cron_interval( $schedules ) {
     $schedules['two_minutes'] = array(
         'interval' => 120,
-        'display'  => esc_html__( 'Every 2 Minutes', 'revisionary' ),
+        'display'  => '120_sec',
     );
+
+    if (did_action('init')) {
+        $schedules['two_minutes']['display'] = esc_html__( 'Every 2 Minutes', 'revisionary' );
+    }
  
     return $schedules;
 }


### PR DESCRIPTION
Fixes #1534

Skip the display caption if this filter is applied prior to the init action. In that case, the filter application stems from another plugin's premature wp_schedule_event() call and the caption won't actually be used.