### PR TITLE
Revision Archive: numerous improvements

### DIFF
--- a/admin/options.php
+++ b/admin/options.php
@@ -177,6 +177,7 @@ $this->option_captions = apply_filters('revisionary_option_captions',
 	'past_revisions_order_by' =>				esc_html__('Past Revisions ordering:', 'revisionary'), 
 	'list_unsubmitted_revisions' => 			sprintf(esc_html__('List %s in Revision Queue for "My Activity" or "Revisions to My Posts" view', 'revisionary'), pp_revisions_status_label('draft-revision', 'plural')),
 	'archive_postmeta' =>						esc_html__('Store custom fields of submitted and scheduled revisions for archive', 'revisionary'),
+	'extended_archive' =>						esc_html__('Keep an archive of revision edits, even after the revision is published', 'revisionary'),
 	'rev_publication_delete_ed_comments' =>		esc_html__('On Revision publication, delete Editorial Comments', 'revisionary'),
 	'deletion_queue' => 						esc_html__('Enable deletion queue', 'revisionary'),
 	'revision_archive_deletion' => 				esc_html__('Enable deletion in archive', 'revisionary'),
@@ -206,7 +207,7 @@ $this->form_options = apply_filters('revisionary_option_sections', [
 	'pending_revisions'	=> 	 ['pending_revisions', 'revise_posts_capability', 'pending_revision_update_post_date', 'pending_revision_update_modified_date'],
 	'revision_queue' =>		 ['manage_unsubmitted_capability', 'revisor_lock_others_revisions', 'revisor_hide_others_revisions', 'admin_revisions_to_own_posts', 'list_unsubmitted_revisions', 'deletion_queue'],
 	'preview' =>			 ['revision_preview_links', 'preview_link_type', 'preview_link_alternate_preview_arg', 'home_preview_set_home_flag', 'block_editor_extra_preview_button', 'compare_revisions_direct_approval', 'diff_display_strip_tags', 'past_revisions_order_by'],
-	'revisions'		=>		 ['require_edit_others_drafts', 'trigger_post_update_actions', 'copy_revision_comments_to_post', 'archive_postmeta', 'rev_publication_delete_ed_comments', 'revision_archive_deletion', 'revision_restore_require_cap', 'revision_statuses_noun_labels', 'display_hints', 'delete_settings_on_uninstall'],
+	'revisions'		=>		 ['require_edit_others_drafts', 'trigger_post_update_actions', 'copy_revision_comments_to_post', 'archive_postmeta', 'extended_archive', 'rev_publication_delete_ed_comments', 'revision_archive_deletion', 'revision_restore_require_cap', 'revision_statuses_noun_labels', 'display_hints', 'delete_settings_on_uninstall'],
 	'notification'	=>		 ['use_publishpress_notifications', 'planner_notifications_access_limited', 'pending_rev_notify_admin', 'pending_rev_notify_author', 'revision_update_notifications', 'rev_approval_notify_admin', 'rev_approval_notify_author', 'rev_approval_notify_revisor', 'publish_scheduled_notify_admin', 'publish_scheduled_notify_author', 'publish_scheduled_notify_revisor', 'use_notification_buffer'],
 	'license' =>			 ['edd_key'],
 ]
@@ -858,6 +859,8 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 		$this->option_checkbox( 'trigger_post_update_actions', $tab, $section, $hint, '' );
 
 		echo '<h4 style="margin-top: 30px; margin-bottom:0">' . esc_html__('Revision Archive:', 'revisionary') . '</h4>';
+
+		$this->option_checkbox( 'extended_archive', $tab, $section, '', '' );
 
 		$this->option_checkbox( 'archive_postmeta', $tab, $section, '', '' );
 

--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -958,7 +958,7 @@ function rvy_apply_revision( $revision_id, $actual_revision_status = '' ) {
 		}
 	}
 	
-	rvy_update_post_meta($revision_id, '_rvy_published_gmt', $post_modified_gmt);
+	rvy_update_post_meta($revision_id, '_rvy_published_gmt', current_time('mysql', 1));
 
 	rvy_update_post_meta($revision_id, '_rvy_prev_revision_status', $actual_revision_status);
 
@@ -1055,9 +1055,11 @@ function rvy_apply_revision( $revision_id, $actual_revision_status = '' ) {
 		);
 	}
 
-	rvy_delete_past_revisions($revision_id);
+	if (!rvy_get_option('extended_archive')) {
+		rvy_delete_past_revisions($revision_id);
 
-	rvy_delete_redundant_revisions($revision);
+		rvy_delete_redundant_revisions($revision);
+	}
 
 	clean_post_cache($revision_id);
 	clean_post_cache($published->ID);

--- a/defaults_rvy.php
+++ b/defaults_rvy.php
@@ -68,6 +68,7 @@ function rvy_default_options_sitewide() {
 		'permissions_compat_mode' => true,
 		'planner_notifications_access_limited' => false,
 		'archive_postmeta' => true,
+		'extended_archive' => true,
 		'delete_settings_on_uninstall' => true
 	);
 
@@ -136,6 +137,7 @@ function rvy_default_options() {
 		'permissions_compat_mode' => 0,
 		'planner_notifications_access_limited' => 0,
 		'archive_postmeta' => 0,
+		'extended_archive' => 0,
 		'delete_settings_on_uninstall' => 0,
 	);
 

--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -534,7 +534,7 @@ class Revisionary
 			}
 
 			if (empty($revision_updaters[$current_user->ID])) {
-				$revision_updaters[$current_user->ID] = true;
+				$revision_updaters[$current_user->ID] = current_time( 'mysql', 1 );
 				rvy_update_post_meta($post_id, '_rvy_updated_by', $revision_updaters);
 			}
 		}
@@ -665,7 +665,7 @@ class Revisionary
 
 		if ( $revisions = rvy_get_post_revisions( $post_id, '', array( 'order' => 'DESC', 'orderby' => 'ID' ) ) ) {  // @todo: retrieve revision_id in block editor js, pass as redirect arg
 			foreach( $revisions as $revision ) {
-				if (rvy_is_post_author($revision, $user_id)) {
+				if ((false === $user_id) || rvy_is_post_author($revision, $user_id)) {
 					return $revision;
 				}
 			}


### PR DESCRIPTION
* Feature : Revision Archive - option to archive past updates of Pending / Scheduled Revisions, even after publication
* Feature : Archive - Include action link "Edit Parent"
* Feature : Archive - "Edit Parent" tool tip provides context by specifying "Parent post" or "Parent revision"
* Change : Archive - Recaption "Method" to "Action"
* Change : Archive - Clarify Action captions for "Revision Publication" and "Scheduled Revision Publication"
* Change : Archive - For direct edits, show same user in Revised By and Approved By fields
* Change : Archive - Hide Count column, which is redundant in this context
* Fixed : Archive - Action caption for past updates of Submitted / Scheduled revisions: "Edit of Submitted Revision", etc.
* Fixed : Archive - Published Date was displayed for past updates of Submitted / Scheduled revisions even though the revision has not been published
* Fixed : Archive - Wrong publication date listed for direct edits
* Fixed : Archive - Wrong publication date displayed for published revisions under some conditions
* Fixed : Archive - Bulk deletion checkbox was displayed even if revision archive deletion is disabled

Fixes #1542