### PR TITLE
Clarify captions for capability requirement settings

### DIFF
--- a/admin/admin_rvy.php
+++ b/admin/admin_rvy.php
@@ -210,6 +210,8 @@ class RevisionaryAdmin
 		
 		if ((!empty($_REQUEST['page']) && in_array($_REQUEST['page'], ['revisionary-settings', 'rvy-net_options', 'rvy-default_options']))) {		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			wp_enqueue_script('revisionary-settings', RVY_URLPATH . '/admin/settings.js', [], PUBLISHPRESS_REVISIONS_VERSION);
+
+			wp_enqueue_style('revisionary-tooltip', RVY_URLPATH . '/common/css/_tooltip.css', [], PUBLISHPRESS_REVISIONS_VERSION);
 		}
 		
 		if (defined('PUBLISHPRESS_REVISIONS_PRO_VERSION') && ('admin.php' == $pagenow) && !empty($_REQUEST['page']) && in_array($_REQUEST['page'], ['revisionary-settings', 'rvy-net_options', 'rvy-default_options']) ) {	//phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -389,15 +391,31 @@ class RevisionaryAdmin
 			$section_caps['PublishPress Revisions'] []= 'restore_revisions';
 		}
 
+		if (!rvy_get_option('manage_unsubmitted_capability')) {
+			$section_caps['PublishPress Revisions'] = array_diff($section_caps['PublishPress Revisions'], ['manage_unsubmitted_revisions']);
+		}
+
+		if (!rvy_get_option('require_edit_others_drafts')) {
+			$section_caps['PublishPress Revisions'] = array_diff($section_caps['PublishPress Revisions'], ['edit_others_drafts']);
+		}
+
+		if (!rvy_get_option('revisor_hide_others_revisions')) {
+			$section_caps['PublishPress Revisions'] = array_diff($section_caps['PublishPress Revisions'], ['list_others_revisions']);
+		}
+
+		if (!rvy_get_option('revisor_lock_others_revisions')) {
+			$section_caps['PublishPress Revisions'] = array_diff($section_caps['PublishPress Revisions'], ['edit_others_revisions']);
+		}
+
 		return $section_caps;
 	}
 
 	public function fltCapDescriptions($cap_descripts)
 	{
 		$cap_descripts['edit_others_drafts'] = esc_html__('Bypass Revisions setting "Prevent Revisors from editing other user\'s drafts."', 'revisionary');
-		$cap_descripts['edit_others_revisions'] = esc_html__('Satisfy Revisions setting "Editing others\' revisions requires role capability."', 'revisionary');
-		$cap_descripts['list_others_revisions'] = esc_html__('Satisfy Revisions setting "Editing others\' revisions requires role capability."', 'revisionary');
-		$cap_descripts['manage_unsubmitted_revisions'] = esc_html__('Satisfy Revisions setting "Additional role capability required to manage Unsubmitted Revisions."', 'revisionary');
+		$cap_descripts['edit_others_revisions'] = esc_html__('Satisfy Revisions setting "Editing others\' Revisions requires role capability."', 'revisionary');
+		$cap_descripts['list_others_revisions'] = esc_html__('Satisfy Revisions setting "Listing others\' Revisions requires role capability."', 'revisionary');
+		$cap_descripts['manage_unsubmitted_revisions'] = esc_html__('Satisfy Revisions setting "Managing Unsubmitted Revisions requires role capability."', 'revisionary');
 		$cap_descripts['preview_others_revisions'] = esc_html__('Preview other user\'s Revisions (without needing editing access).', 'revisionary');
 		$cap_descripts['restore_revisions'] = esc_html__('Restore an archived Revision as the current revision.', 'revisionary');
 

--- a/admin/options.php
+++ b/admin/options.php
@@ -37,6 +37,14 @@ class RvyOptionUI {
 		$this->display_hints = rvy_get_option( 'display_hints' );
     }
 
+	function tooltipText($display_text, $tip_text) {
+		return '<span data-toggle="tooltip" data-placement="top"><span class="tooltip-text"><span>' 
+		. $tip_text
+		. '</span><i></i></span>'
+		. $display_text
+		. '</span>';
+	}
+
 	function option_checkbox( $option_name, $tab_name, $section_name, $hint_text, $unused_arg = '', $args = '') {
 		$return = array( 'in_scope' => false, 'val' => '', 'subcaption' => '', 'style' => '', 'hide' => false, 'no_escape' => false );
 
@@ -68,8 +76,17 @@ class RvyOptionUI {
 
 			echo "</label>";
 
-			if ( $hint_text && $this->display_hints )
-				echo "<div class='rvy-subtext'>" . esc_html($hint_text) . "</div>";
+			if ( $hint_text && $this->display_hints ) {
+				echo "<div class='rvy-subtext'>";
+				
+				if (!empty($args['no_escape'])) {
+					echo $hint_text;
+				} else {
+					echo esc_html($hint_text);
+				}
+				
+				echo "</div>";
+			}
 
 			if ( ! empty($args['subcaption']) )
 				echo $args['subcaption'];		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -133,8 +150,8 @@ $pp_notif_url = admin_url('edit.php?post_type=psppnotif_workflow');
 $this->option_captions = apply_filters('revisionary_option_captions',
 	[
 	'revision_statuses_noun_labels' =>			esc_html__('Use alternate labeling: "Working Copy" > "Change Request" > "Scheduled Change"', 'revisionary'),
-	'manage_unsubmitted_capability' =>			sprintf(esc_html__('Additional role capability required to manage %s', 'revisionary'), pp_revisions_status_label('draft-revision', 'plural')),
-	'copy_posts_capability' =>					rvy_get_option('revision_statuses_noun_labels') ? esc_html__("Additional role capability required to create a Working Copy", 'revisionary') : esc_html__("Additional role capability required to create a new revision", 'revisionary'),
+	'manage_unsubmitted_capability' =>			sprintf(esc_html__('Managing %s requires role capability', 'revisionary'), pp_revisions_status_label('draft-revision', 'plural')),
+	'copy_posts_capability' =>					rvy_get_option('revision_statuses_noun_labels') ? esc_html__("Working Copy creation requires role capability", 'revisionary') : esc_html__("Revision creation requires role capability", 'revisionary'),
 	'caption_copy_as_edit' =>					sprintf(esc_html__('Posts / Pages list: Use "Edit" caption for %s link', 'revisionary'), pp_revisions_status_label('draft-revision', 'submit_short')),
 	'pending_revisions' => 						sprintf(esc_html__('Enable %s', 'revisionary'), $pending_revision_plural),
 	'revision_limit_per_post' =>				esc_html__("Limit to one active revision per post", 'revisionary'),
@@ -142,9 +159,9 @@ $this->option_captions = apply_filters('revisionary_option_captions',
 	'revision_unfiltered_html_check' =>			esc_html__("If post contains custom html, require unfiltered_html capability", 'revisionary'),
 	'auto_submit_revisions' =>					esc_html__("Auto-submit revisions created by a user with publishing capability", 'revisionary'),
 	'scheduled_revisions' => 					sprintf(esc_html__('Enable %s', 'revisionary'), pp_revisions_status_label('future-revision', 'plural')),
-	'revise_posts_capability' =>				rvy_get_option('revision_statuses_noun_labels') ? esc_html__("Additional role capability required to submit a Change Request", 'revisionary') : esc_html__("Additional role capability required to submit a revision", 'revisionary'),
-	'revisor_lock_others_revisions' =>			esc_html__("Editing others' revisions requires role capability", 'revisionary'),
-	'revisor_hide_others_revisions' => 			esc_html__("Listing others' revisions requires role capability", 'revisionary'),
+	'revise_posts_capability' =>				rvy_get_option('revision_statuses_noun_labels') ? esc_html__("Change Request submission require role capability", 'revisionary') : esc_html__("Revision submission requires role capability", 'revisionary'),
+	'revisor_lock_others_revisions' =>			esc_html__("Editing others' Revisions requires role capability", 'revisionary'),
+	'revisor_hide_others_revisions' => 			esc_html__("Listing others' Revisions requires role capability", 'revisionary'),
 	'admin_revisions_to_own_posts' =>			esc_html__("Users can always administer revisions to their own editable posts", 'revisionary'),
 	'revision_update_notifications' =>			esc_html__('Also notify on Revision Update', 'revisionary'),
 	'trigger_post_update_actions' => 			esc_html__('Apply API actions to mimic Post Update', 'revisionary'),
@@ -164,7 +181,7 @@ $this->option_captions = apply_filters('revisionary_option_captions',
 	'publish_scheduled_notify_revisor' => 		sprintf(esc_html__('Email the Revisor when a %s is published', 'revisionary'), $future_revision_singular),
 	'use_notification_buffer' => 				esc_html__('Enable notification buffer', 'revisionary'),
 	'revisor_role_add_custom_rolecaps' => 		esc_html__('All custom post types available to Revisors', 'revisionary' ),
-	'require_edit_others_drafts' => 			esc_html__("Prevent Revisors from editing other user's drafts", 'revisionary' ),
+	'require_edit_others_drafts' => 			esc_html__("Prevent Revisors from editing others' unpublished Posts", 'revisionary' ),
 	'display_hints' => 							esc_html__('Display Hints', 'revisionary'),
 	'delete_settings_on_uninstall' => 			esc_html__('Delete settings and Revisions if plugin is deleted', 'revisionary'),
 	'revision_preview_links' => 				esc_html__('Show Preview Links', 'revisionary'),
@@ -181,7 +198,7 @@ $this->option_captions = apply_filters('revisionary_option_captions',
 	'rev_publication_delete_ed_comments' =>		esc_html__('On Revision publication, delete Editorial Comments', 'revisionary'),
 	'deletion_queue' => 						esc_html__('Enable deletion queue', 'revisionary'),
 	'revision_archive_deletion' => 				esc_html__('Enable deletion in archive', 'revisionary'),
-	'revision_restore_require_cap' =>			esc_html__('Additional role capability required to restore a revision', 'revisionary'),
+	'revision_restore_require_cap' =>			esc_html__('Restoring a Revision requires role capability', 'revisionary'),
 	'permissions_compat_mode' => 				esc_html__('Compatibility Mode', 'revisionary'),
 	'planner_notifications_access_limited' =>	esc_html__('Planner Notifications Access-Limited', 'revisionary'),
 	]
@@ -579,16 +596,66 @@ if ( ! empty( $this->form_options[$tab][$section] ) ) :?>
 	$hint = sprintf(esc_html__('If the user does not have a regular Edit link, recaption the %s link as "Edit."', 'revisionary'), pp_revisions_status_label('draft-revision', 'submit_short'));
 	$this->option_checkbox( 'caption_copy_as_edit', $tab, $section, $hint, '' );
 
-	$hint = esc_html__('This restriction applies to users who are not full editors for the post type. To enable a role, add capabilities: copy_posts, copy_others_pages, etc.', 'revisionary');
-	
+	$checkbox_args = [];
+
+	if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+		$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=copy');
+
+		$hint = sprintf(
+			__('If checked, users who cannot edit the published post will need %s.', 'revisionary'),
+			
+			$this->tooltipText(
+				"<a href='$url'>" . __('Create Revision capabilities', 'revisionary') . '</a>',
+				__('Assign capabilities to roles', 'revisionary')
+			)
+		);
+
+		$checkbox_args['no_escape'] = true;
+	} else {
+		$hint = esc_html__('If checked, users who cannot edit the published post will need Create Revision capabilities (copy_posts, copy_others_pages, etc.)', 'revisionary');
+	}
+
 	if (defined('PRESSPERMIT_VERSION')) {
-		$hint .= ' ' . esc_html__('To expand the Posts / Pages listing for non-Editors, add capabilities: list_others_pages, list_published_posts, etc.', 'revisionary');
+		if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+			$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=list');
+	
+			$hint .= ' ' . sprintf(
+				__('To assign the Posts / Pages list, assign %s.', 'revisionary'),
+				
+				$this->tooltipText(
+					"<a href='$url'>" . __('Listing capabilities', 'revisionary') . '</a>',
+					__('Assign capabilities to roles', 'revisionary')
+				)
+			);
+	
+			$checkbox_args['no_escape'] = true;
+		} else {
+			$hint .= ' ' . esc_html__('To expand the Posts / Pages list, assign Listing capabilities (list_others_pages, list_published_posts, etc.)', 'revisionary');
+		}
 	}
 	
-	$this->option_checkbox( 'copy_posts_capability', $tab, $section, $hint, '' );
+	$this->option_checkbox( 'copy_posts_capability', $tab, $section, $hint, '', $checkbox_args );
 
-	$hint = esc_html__('If disabled, revision by a user who does not have the unfiltered_html capability will cause all custom html tags to be stripped out.', 'revisionary');
-	$this->option_checkbox( 'revision_unfiltered_html_check', $tab, $section, $hint, '' );
+	$checkbox_args = [];
+
+	if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+		$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=admin');
+
+		$hint = sprintf(
+			__('Revision by a user who does not have the %s will cause all custom html tags to be stripped out.', 'revisionary'),
+			
+			$this->tooltipText(
+				"<a href='$url'>" . sprintf(__('%s capability', 'revisionary'), 'unfiltered_html') . '</a>',
+				__('Assign capability to roles', 'revisionary')
+			)
+		);
+
+		$checkbox_args['no_escape'] = true;
+	} else {
+		$hint = esc_html__('Revision by a user who does not have the unfiltered_html capability will cause all custom html tags to be stripped out.', 'revisionary');
+	}
+
+	$this->option_checkbox( 'revision_unfiltered_html_check', $tab, $section, $hint, '', $checkbox_args );
 	?>
 
 	<?php
@@ -622,8 +689,26 @@ $pending_revisions_available ) :
 		)
 		. "</div>";
 
-		$hint = esc_html__('This restriction applies to users who are not full editors for the post type. To enable a role, add capabilities: revise_posts, revise_others_pages, etc.', 'revisionary');
-		$this->option_checkbox( 'revise_posts_capability', $tab, $section, $hint, '' );
+		$checkbox_args = [];
+
+		if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+			$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=revise');
+	
+			$hint = sprintf(
+				__('If checked, users who cannot edit the published post will need %s.', 'revisionary'),
+
+				$this->tooltipText(
+					"<a href='$url'>" . __('Submit Revision capabilities', 'revisionary') . '</a>',
+					__('Assign capabilities to roles', 'revisionary')
+				)
+			);
+
+			$checkbox_args['no_escape'] = true;
+		} else {
+			$hint = esc_html__('If checked, users who cannot edit the published post will need Submit Revision capabilities (revise_posts, revise_others_pages, etc.)', 'revisionary');
+		}
+
+		$this->option_checkbox( 'revise_posts_capability', $tab, $section, $hint, '', $checkbox_args );
 
 		$hint = sprintf(esc_html__( 'When a %s is published, update post publish date to current time.', 'revisionary' ), pp_revisions_status_label('pending-revision', 'name'));
 		$this->option_checkbox( 'pending_revision_update_post_date', $tab, $section, $hint, '' );
@@ -683,14 +768,66 @@ if ( 	// To avoid confusion, don't display any revision settings if pending revi
 			<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 			<?php
-			$hint = esc_html__('To enable a role, add the manage_unsubmitted_revisions capability.', 'revisionary');
-			$this->option_checkbox('manage_unsubmitted_capability', $tab, $section, $hint, '');
-	
-			$hint = esc_html__('This restriction applies to users who are not full editors for the post type. To enable a role, give it the edit_others_revisions capability.', 'revisionary');
-			$this->option_checkbox( 'revisor_lock_others_revisions', $tab, $section, $hint, '' );
+			$checkbox_args = [];
 
-			$hint = esc_html__('This restriction applies to users who are not full editors for the post type. To enable a role, give it the list_others_revisions capability.', 'revisionary');
-			$this->option_checkbox( 'revisor_hide_others_revisions', $tab, $section, $hint, '' );
+			if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+				$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=publishpress-revisions');
+
+				$hint = sprintf(
+					__('Users will need the %s to edit others\' Unsubmitted Revisions.', 'revisionary'),
+
+					$this->tooltipText(
+						"<a href='$url'>" . sprintf(__('%s capability', 'revisionary'), 'manage_unsubmitted_revisions') . '</a>',
+						__('Assign capability to roles', 'revisionary')
+					)
+				);
+
+				$checkbox_args['no_escape'] = true;
+			} else {
+				$hint = esc_html__('Users will need the manage_unsubmitted_revisions capability to edit others\' Unsubmitted Revisions.', 'revisionary');
+			}
+
+			$this->option_checkbox('manage_unsubmitted_capability', $tab, $section, $hint, '', $checkbox_args);
+
+			if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+				$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=publishpress-revisions');
+		
+				$hint = sprintf(
+					__('If checked, users who cannot edit the published post will need the %s.', 'revisionary'),
+					
+					$this->tooltipText(
+						"<a href='$url'>" . sprintf(__('%s capability', 'revisionary'), 'edit_others_revisions') . '</a>',
+						__('Assign capability to roles', 'revisionary')
+					)
+				);
+
+				$checkbox_args['no_escape'] = true;
+			} else {
+				$hint = esc_html__('If checked, users who cannot edit the published post will need the edit_others_revisions capability.', 'revisionary');
+			}
+
+			$this->option_checkbox( 'revisor_lock_others_revisions', $tab, $section, $hint, '', $checkbox_args );
+
+			$checkbox_args = [];
+
+			if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+				$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=publishpress-revisions');
+		
+				$hint = sprintf(
+					__('If checked, users who cannot edit the published post will need the %s.', 'revisionary'),
+					
+					$this->tooltipText(
+						"<a href='$url'>" . sprintf(__('%s capability', 'revisionary'), 'list_others_revisions') . '</a>',
+						__('Assign capability to roles', 'revisionary')
+					)
+				);
+
+				$checkbox_args['no_escape'] = true;
+			} else {
+				$hint = esc_html__('If checked, users who cannot edit the published post will need the list_others_revisions capability.', 'revisionary');
+			}
+
+			$this->option_checkbox( 'revisor_hide_others_revisions', $tab, $section, $hint, '', $checkbox_args );
 
 			$hint = esc_html__('Bypass the above restrictions for others\' revisions to logged in user\'s own posts.', 'revisionary');
 			$this->option_checkbox( 'admin_revisions_to_own_posts', $tab, $section, $hint, '' );
@@ -842,8 +979,26 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 		<table class="form-table rs-form-table" id="<?php echo esc_attr("ppr-tab-$section");?>"<?php echo ($setActiveTab != $section) ? ' style="display:none;"' : '' ?>><tr><td>
 
 		<?php
-		$hint = esc_html__('If checked, the edit_others_drafts capability will be required for users lacking site-wide publishing capabilities', 'revisionary');
-		$this->option_checkbox( 'require_edit_others_drafts', $tab, $section, $hint, '' );
+		$checkbox_args = [];
+
+		if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+			$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=publishpress-revisions');
+	
+			$hint = sprintf(
+				__('If checked, users who can\'t publish will need the %s to edit others\' unpublished Posts.', 'revisionary'),
+				
+				$this->tooltipText(
+					"<a href='$url'>" . sprintf(__('%s capability', 'revisionary'), 'edit_others_drafts') . '</a>',
+					__('Assign capability to roles', 'revisionary')
+				)
+			);
+
+			$checkbox_args['no_escape'] = true;
+		} else {
+			$hint = esc_html__('If checked, users who can\'t publish will need the edit_others_drafts capability to edit others\' unpublished Posts.', 'revisionary');
+		}
+
+		$this->option_checkbox( 'require_edit_others_drafts', $tab, $section, $hint, '', $checkbox_args );
 		?>
 
 		<?php
@@ -868,8 +1023,26 @@ $pending_revisions_available || $scheduled_revisions_available ) :
 		$this->option_checkbox( 'revision_archive_deletion', $tab, $section, $hint, '' );
 
 		if (defined('PUBLISHPRESS_REVISIONS_PRO_VERSION')) {
-			$hint = esc_html__('Non-Administrators cannot restore a revision without the restore_revisions capability', 'revisionary');
-			$this->option_checkbox( 'revision_restore_require_cap', $tab, $section, $hint, '' );
+			$checkbox_args = [];
+			
+			if (defined('PUBLISHPRESS_CAPS_VERSION')) {
+				$url = admin_url('admin.php?page=pp-capabilities&pp_caps_tab=publishpress-revisions');
+		
+				$hint = sprintf(
+					__('If checked, non-Administrators cannot restore a revision without the %s.', 'revisionary'),
+					
+					$this->tooltipText(
+						"<a href='$url'>" . sprintf(__('%s capability', 'revisionary'), 'restore_revisions') . '</a>',
+						__('Assign capability to roles', 'revisionary')
+					)
+				);
+	
+				$checkbox_args['no_escape'] = true;
+			} else {
+				$hint = esc_html__('If checked, non-Administrators cannot restore a revision without the restore_revisions capability', 'revisionary');
+			}
+
+			$this->option_checkbox( 'revision_restore_require_cap', $tab, $section, $hint, '', $checkbox_args );
 		}
 
 		do_action('revisionary_option_ui_revision_options', $this, $sitewide, $customize_defaults);

--- a/common/css/_tooltip.css
+++ b/common/css/_tooltip.css
@@ -1,0 +1,104 @@
+[data-toggle="tooltip"] {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+  /* Tooltip Box */
+  /* Placements */
+}
+[data-toggle="tooltip"] .tooltip-text {
+  display: none;
+  position: absolute;
+  min-width: 200px;
+  padding: 16px;
+  font-size: 13px;
+  font-weight: normal;
+  text-align: center;
+  color: #fff;
+  background-color: #000c0c;
+  border: 1px solid #d5d5d5;
+  border-radius: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1), 0 0 56px rgba(0, 0, 0, 0.08);
+  z-index: 99999999;
+  box-sizing: border-box;
+  transform: translate(-50%, -100%);
+  transition: all 0.65s cubic-bezier(0.84, -0.18, 0.31, 1.26);
+  white-space: normal;
+  font-style: normal;
+  /* Arrow */
+}
+[data-toggle="tooltip"] .tooltip-text a {
+  color: #a0e0ff;
+  text-decoration: underline;
+  transition: color 0.2s;
+  font-size: 13px !important;
+}
+[data-toggle="tooltip"] .tooltip-text a:hover {
+  color: #39b6f5;
+}
+[data-toggle="tooltip"] .tooltip-text i {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  width: 24px;
+  height: 12px;
+  margin-left: -6px;
+  overflow: hidden;
+}
+[data-toggle="tooltip"] .tooltip-text i::after {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  left: 50%;
+  background-color: #000c0c;
+  transform: translate(-50%, -50%) rotate(45deg);
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
+}
+[data-toggle="tooltip"]:not(.click):hover .tooltip-text,
+[data-toggle="tooltip"]:not(.click):focus-within .tooltip-text {
+  display: block;
+}
+[data-toggle="tooltip"].click.is-active .tooltip-text {
+  display: block;
+}
+[data-toggle="tooltip"]:not([data-placement]) .tooltip-text,
+[data-toggle="tooltip"][data-placement="top"] .tooltip-text {
+  top: -10px;
+  left: 50%;
+  transform: translate(-50%, -100%);
+}
+[data-toggle="tooltip"]:not([data-placement]) .tooltip-text i,
+[data-toggle="tooltip"][data-placement="top"] .tooltip-text i {
+  margin-left: -12px;
+}
+[data-toggle="tooltip"][data-placement="bottom"] .tooltip-text {
+  top: 100%;
+  left: 25%;
+  transform: translate(-50%, 0);
+  margin-top: 10px;
+}
+[data-toggle="tooltip"][data-placement="bottom"] .tooltip-text i {
+  top: -12px;
+  transform: rotate(180deg);
+}
+[data-toggle="tooltip"][data-placement="left"] .tooltip-text {
+  top: 50%;
+  left: -10px;
+  transform: translate(-100%, -50%);
+}
+[data-toggle="tooltip"][data-placement="left"] .tooltip-text i {
+  top: 50%;
+  left: 100%;
+  transform: translateY(-50%) rotate(-90deg);
+}
+[data-toggle="tooltip"][data-placement="right"] .tooltip-text {
+  top: 50%;
+  left: 100%;
+  transform: translate(0, -50%);
+  margin-left: 10px;
+}
+[data-toggle="tooltip"][data-placement="right"] .tooltip-text i {
+  top: 50%;
+  left: -12px;
+  transform: translateY(-50%) rotate(90deg);
+}

--- a/common/css/_tooltip.less
+++ b/common/css/_tooltip.less
@@ -1,0 +1,118 @@
+[data-toggle="tooltip"] {
+  position: relative;
+  display: inline-block;
+  cursor: pointer;
+
+  /* Tooltip Box */
+  .tooltip-text {
+    display: none;
+    position: absolute;
+    min-width: 200px;
+    padding: 16px;
+    font-size: 13px;
+    font-weight: normal;
+    text-align: left;
+    color: #fff;
+    background-color: #000c0c;
+    border: 1px solid #d5d5d5;
+    border-radius: 10px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1), 0 0 56px rgba(0, 0, 0, 0.08);
+    z-index: 99999999;
+    box-sizing: border-box;
+    transform: translate(-50%, -100%);
+    transition: all 0.65s cubic-bezier(0.84, -0.18, 0.31, 1.26);
+    white-space: normal;
+    font-style: normal;
+
+    a {
+      color: #a0e0ff;
+      text-decoration: underline;
+      transition: color 0.2s;
+      font-size: 13px !important;
+
+      &:hover {
+        color: #39b6f5;
+      }
+    }
+
+    /* Arrow */
+    i {
+      position: absolute;
+      top: 100%;
+      left: 50%;
+      width: 24px;
+      height: 12px;
+      margin-left: -6px;
+      overflow: hidden;
+
+      &::after {
+        content: '';
+        position: absolute;
+        width: 12px;
+        height: 12px;
+        left: 50%;
+        background-color: #000c0c;
+        transform: translate(-50%, -50%) rotate(45deg);
+        box-shadow: 0 1px 8px rgba(0, 0, 0, 0.5);
+      }
+    }
+  }
+
+  &:not(.click):hover .tooltip-text,
+  &:not(.click):focus-within .tooltip-text {
+    display: block;
+  }
+
+  &.click.is-active .tooltip-text {
+    display: block;
+  }
+
+  /* Placements */
+  &:not([data-placement]) .tooltip-text,
+  &[data-placement="top"] .tooltip-text {
+    top: -10px;
+    left: 50%;
+    transform: translate(-50%, -100%);
+
+    i {
+      margin-left: -12px;
+    }
+  }
+
+  &[data-placement="bottom"] .tooltip-text {
+    top: 100%;
+    left: 25%;
+    transform: translate(-50%, 0);
+    margin-top: 10px;
+
+    i {
+      top: -12px;
+      transform: rotate(180deg);
+    }
+  }
+
+  &[data-placement="left"] .tooltip-text {
+    top: 50%;
+    left: -10px;
+    transform: translate(-100%, -50%);
+
+    i {
+      top: 50%;
+      left: 100%;
+      transform: translateY(-50%) rotate(-90deg);
+    }
+  }
+
+  &[data-placement="right"] .tooltip-text {
+    top: 50%;
+    left: 100%;
+    transform: translate(0, -50%);
+    margin-left: 10px;
+
+    i {
+      top: 50%;
+      left: -12px;
+      transform: translateY(-50%) rotate(90deg);
+    }
+  }
+}


### PR DESCRIPTION
Improve clarity and consistency of captions for capability requirement settings. Link to Capabilities tab for capability assignment, with tooltip explanation.

Closes #522