### PR TITLE
If Past Revisions or New Revisions are disabled for all post types, suppress menus and tabs

### DIFF
--- a/admin/admin_rvy.php
+++ b/admin/admin_rvy.php
@@ -268,7 +268,7 @@ class RevisionaryAdmin
 	}
 
 	function build_menu() {
-		global $current_user;
+		global $current_user, $revisionary;
 
 		if ( isset($_SERVER['REQUEST_URI']) && (strpos( esc_url_raw($_SERVER['REQUEST_URI']), 'wp-admin/network/' )) )
 			return;
@@ -306,20 +306,23 @@ class RevisionaryAdmin
 
 			if ($can_edit_any) {
 				$menu_func = [$this, 'moderation_queue'];
-			} else {
+			} elseif ($revision_archive && array_filter($revisionary->enabled_post_types_archive)) {
 				$menu_slug = 'revisionary-archive';
 				$menu_func = [$this, 'revision_archive'];
+			} else {
+				$menu_slug = 'revisionary-settings';
+				$menu_func = 'rvy_omit_site_options';
 			}
 
 			add_menu_page( esc_html__($_menu_caption, 'pp'), esc_html__($_menu_caption, 'pp'), 'read', $menu_slug, $menu_func, 'dashicons-backup', 29 );
 
-			if ($can_edit_any) {
+			if ($can_edit_any && array_filter($revisionary->enabled_post_types)) {
 				add_submenu_page('revisionary-q', esc_html__('Revision Queue', 'revisionary'), esc_html__('Revision Queue', 'revisionary'), 'read', 'revisionary-q', [$this, 'moderation_queue']);
 			}
 
 			do_action('revisionary_admin_menu');
 
-			if ($revision_archive) {
+			if ($revision_archive && array_filter($revisionary->enabled_post_types_archive)) {
 				// Revision Archive page
 				add_submenu_page(
 					$menu_slug,

--- a/admin/options.php
+++ b/admin/options.php
@@ -381,6 +381,19 @@ if ( rvy_get_option('display_hints', $sitewide, $customize_defaults) ) {
 	</div>
 	<?php
 }
+
+if (empty(array_filter($revisionary->enabled_post_types_archive))) {
+	unset($this->section_captions['features']['archive']);
+}
+
+if (empty(array_filter($revisionary->enabled_post_types))) {
+	unset($this->section_captions['features']['working_copy']);
+}
+
+if (empty(array_filter($revisionary->enabled_post_types)) && empty(array_filter($revisionary->enabled_post_types_archive))) {
+	unset($this->section_captions['features']['preview']);
+	unset($this->section_captions['features']['compare']);
+}
 ?>
 
 <ul id="publishpress-revisions-settings-tabs" class="nav-tab-wrapper">

--- a/admin/revisionary.css
+++ b/admin/revisionary.css
@@ -431,7 +431,10 @@ body.revisions_page_revisionary-deletion h1 span.dashicons,
 body.revisions_page_revisionary-settings h1 span.dashicons,
 body.revisions_page_rvy-net_options h1 span.dashicons,
 body.revisions_page_rvy-default_options h1 span.dashicons,
-body.revisions_page_revisionary-archive h1 span.dashicons {
+body.revisions_page_revisionary-archive h1 span.dashicons,
+body.toplevel_page_revisionary-archive h1 span.dashicons,
+body.toplevel_page_revisionary-settings h1 span.dashicons
+{
 padding-top:5px;
 }
 
@@ -448,55 +451,69 @@ padding-top: 4px;
 padding-bottom: 4px;
 }
 
-body.revisions_page_revisionary-settings #poststuff {
+body.revisions_page_revisionary-settings #poststuff,
+body.toplevel_page_revisionary-settings #poststuff
+{
 padding-top: 0;
 }
 
-body.revisions_page_revisionary-settings .form-table td {
+body.revisions_page_revisionary-settings .form-table td,
+body.toplevel_page_revisionary-settings .form-table td
+{
 padding-top: 10px;
 }
 
-body.revisions_page_revisionary-settings #rvy-features > div > table > tbody > tr > td > div.rvy-opt-wrap {
+#rvy-features > div > table > tbody > tr > td > div.rvy-opt-wrap {
 padding-left: 4px;
 padding-right: 4px;
+/*
+overflow: auto;
+max-height: calc(80vh - 150px);
+*/
 }
 
-body.revisions_page_revisionary-settings #rvy-features > div > table > tbody > tr > td > div.rvy-opt-wrap > div {
+#rvy-features > div > table > tbody > tr > td > div.rvy-opt-wrap > div {
 padding-top: 2px;
 }
 
-body.revisions_page_revisionary-settings div.submit, body.revisions_page_rvy-net_options div.submit, body.revisions_page_rvy-default_options div.submit {
+#rvy-features div.submit
+{
 padding-top:0;
 }
 
-body.revisions_page_revisionary-settings input[type="checkbox"] {
+#rvy-features input[type="checkbox"] {
 vertical-align: middle;
 }
 
-body.revisions_page_revisionary-settings .rvy-subtext a,
-body.revisions_page_revisionary-settings .rvy-subtext a:hover,
-body.revisions_page_revisionary-settings .rvy-subtext a:visited
+#rvy-features .rvy-subtext a,
+#rvy-features .rvy-subtext a:hover,
+#rvy-features .rvy-subtext a:visited
 {
 text-decoration: underline;
 }
 
-body.revisions_page_revisionary-settings .rvy-option-section-tabs {
+#rvy-features .rvy-option-section-tabs {
 margin-top: 0;
 margin-bottom: 4px;
 padding: 4px 4px 0 4px;
 }
 
-body.revisions_page_revisionary-settings .rvy-option-section-tabs li {
+#rvy-features .rvy-option-section-tabs li {
 display: inline-table;
 padding: 4px 1px 1px 1px;
 margin-top: 2px;
 }
 
-body.revisions_page_revisionary-settings li.active a {
+#rvy-features li.active a {
 text-decoration: none;
 font-weight: bold;
 pointer-events: none;
 color: black
+}
+
+#ppr-tab-post_types [data-toggle="tooltip"] .tooltip-text {
+  min-width: 260px;
+  font-size: 14px;
 }
 
 @media only screen and (max-height: 768px) {
@@ -507,13 +524,13 @@ color: black
 }
 
 @media only screen and (max-width: 384px) {
-  body.revisions_page_revisionary-settings div.rvy-subtext {
+  #rvy-features div.rvy-subtext {
   display: none;
   }
 }
 
 @media only screen and (max-height: 384px) {
-  body.revisions_page_revisionary-settings div.rvy-subtext {
+  #rvy-features div.rvy-subtext {
   display: none;
   }
 }

--- a/revisionary_main.php
+++ b/revisionary_main.php
@@ -360,9 +360,11 @@ class Revisionary
 			'revisionary_enabled_post_types', 
 			array_diff_key(
 				$enabled_post_types,
-				['attachment' => true, 'tablepress_table' => true, 'acf-field-group' => true, 'acf-field' => true, 'nav_menu_item' => true, 'custom_css' => true, 'customize_changeset' => true, 'wp_block' => true, 'wp_template' => true, 'wp_template_part' => true, 'wp_global_styles' => true, 'wp_navigation' => true]
+				['attachment' => true, 'tablepress_table' => true, 'acf-field-group' => true, 'acf-field' => true, 'acf-post-type' => true, 'acf-taxonomy' => true, 'nav_menu_item' => true, 'custom_css' => true, 'customize_changeset' => true, 'wp_block' => true, 'wp_template' => true, 'wp_template_part' => true, 'wp_global_styles' => true, 'wp_navigation' => true, 'ppma_boxes' => true, 'ppmacf_field' => true, 'psppnotif_workflow' => true]
 			)
 		);
+
+		$enabled_post_types = array_intersect_key($enabled_post_types, array_fill_keys(get_post_types([], 'names'), true));
 
 		$this->enabled_post_types = array_merge($this->enabled_post_types, $enabled_post_types);
 
@@ -454,6 +456,11 @@ class Revisionary
 			$enabled_post_types_archive
 		);
 
+		$this->enabled_post_types_archive = array_diff_key(
+			$this->enabled_post_types_archive,
+			['attachment' => true, 'tablepress_table' => true, 'acf-field-group' => true, 'acf-field' => true, 'acf-post-type' => true, 'acf-taxonomy' => true, 'nav_menu_item' => true, 'custom_css' => true, 'customize_changeset' => true, 'wp_block' => true, 'wp_template' => true, 'wp_template_part' => true, 'wp_global_styles' => true, 'wp_navigation' => true, 'ppma_boxes' => true, 'ppmacf_field' => true, 'psppnotif_workflow' => true]
+		);
+		
 		$this->enabled_post_types_archive = apply_filters(
 			'revisionary_archive_post_types', 
 			$this->enabled_post_types_archive


### PR DESCRIPTION
Don't display Revisions plugin submenus or tabs for a feature that's disabled for all post types.