### PR TITLE
Ensure packaged version of wordpress-version-notices is considered for loading

### DIFF
--- a/revisionary.php
+++ b/revisionary.php
@@ -168,6 +168,8 @@ if (!defined('REVISIONARY_FILE') && !$revisionary_loaded_by_pro) {
     ) {
         require_once REVISIONS_INTERNAL_VENDORPATH . '/autoload.php';
     }
+
+	include_once REVISIONS_INTERNAL_VENDORPATH . '/publishpress/wordpress-version-notices/src/include.php';
 }
 
 if (!defined('REVISIONARY_FILE') && (!$revisionary_pro_active || $revisionary_loaded_by_pro)) {


### PR DESCRIPTION
The Composer autoload mechanism does not allow multiple versions of the library to be compared, so execute its include.php manually.