### PR TITLE
Remove the free compatibility items from the "Integrations" tab

### DIFF
--- a/admin/options.php
+++ b/admin/options.php
@@ -2056,8 +2056,8 @@ private function renderCompatibilityPack($integration)
 				<?php endif; ?>
 
 				<?php if (!$integration['available']): ?>
-					<span class="pp-badge"
-						style="background: #9e9e9e;"><?php esc_html_e('Supported', 'revisionary'); ?></span>
+					<!--<span class="pp-badge"
+						style="background: #9e9e9e;"><?php esc_html_e('Supported', 'revisionary'); ?></span>-->
 				<?php else: ?>
 					<span class="pp-badge"
 						style="background: #4caf50;"><?php esc_html_e('Active Plugin', 'revisionary'); ?></span>
@@ -2070,11 +2070,13 @@ private function renderCompatibilityPack($integration)
 
 			<div class="pp-integration-features">
 				<ul>
+					<!--
 					<?php if (!empty($integration['free'])) :?>
 						<li><?php esc_html_e('Supported by PublishPress Revisions', 'revisionary');?></li>
 					<?php else :?>
 						<li><?php esc_html_e('Supported by Revisions Pro', 'revisionary');?></li>
 					<?php endif;?>
+					-->
 
 					<?php foreach ($integration['features'] as $feature): ?>
 						<li><?php echo esc_html($feature); ?></li>
@@ -2148,9 +2150,9 @@ private function renderIntegrations()
 {
 	$int = array_merge(
 		wp_filter_object_list($this->defined_integrations, ['available' => true, 'free' => false]),
-		wp_filter_object_list($this->defined_integrations, ['available' => false, 'free' => false]),
-		wp_filter_object_list($this->defined_integrations, ['available' => true, 'free' => true]),
-		wp_filter_object_list($this->defined_integrations, ['available' => false, 'free' => true])
+		wp_filter_object_list($this->defined_integrations, ['available' => false, 'free' => false])
+		//wp_filter_object_list($this->defined_integrations, ['available' => true, 'free' => true]),
+		//wp_filter_object_list($this->defined_integrations, ['available' => false, 'free' => true])
 	);
 
 	// Render each fallback integration

--- a/classes/PublishPress/Revisionary.php
+++ b/classes/PublishPress/Revisionary.php
@@ -278,6 +278,7 @@ class Revisions {
                 'learn_more_url' => 'https://publishpress.com/knowledge-base/revisions-yoast-seo/'
             ],
 
+            /*
             [
                 'id' => 'litespeed_compatibility',
                 'title' => esc_html__('Litespeed Cache', 'revisionary'),
@@ -434,6 +435,7 @@ class Revisions {
                 'learn_more_url' => 'https://taxopress.com/',
                 'free' => true
             ],
+            */
         ];
 
         foreach (array_keys($integrations) as $i) {


### PR DESCRIPTION
Also remove "supported" caption to avoid implying that other popular plugins in category are incompatible.

Closes #1688