### PR TITLE
Early exits in revision cleanup

### DIFF
--- a/admin/revision-action_rvy.php
+++ b/admin/revision-action_rvy.php
@@ -969,40 +969,36 @@ function rvy_apply_revision( $revision_id, $actual_revision_status = '' ) {
 			*/
 			$revisions_to_keep = wp_revisions_to_keep( $post );
 		
-			if ( $revisions_to_keep < 0 ) {
-				return;
-			}
-		
-			$revisions = wp_get_post_revisions( $post_id, array( 'order' => 'ASC' ) );
-		
-			/**
-			 * Filters the revisions to be considered for deletion.
-			 *
-			 * @since 6.2.0
-			 *
-			 * @param WP_Post[] $revisions Array of revisions, or an empty array if none.
-			 * @param int       $post_id   The ID of the post to save as a revision.
-			 */
-			$revisions = apply_filters(
-				'wp_save_post_revision_revisions_before_deletion',
-				$revisions,
-				$post_id
-			);
-		
-			$delete = count( $revisions ) - $revisions_to_keep;
-		
-			if ( $delete < 1 ) {
-				return;
-			}
-		
-			$revisions = array_slice( $revisions, 0, $delete );
-		
-			for ( $i = 0; isset( $revisions[ $i ] ); $i++ ) {
-				if ( str_contains( $revisions[ $i ]->post_name, 'autosave' ) ) {
-					continue;
+			if ($revisions_to_keep >= 0 ) {
+				$revisions = wp_get_post_revisions( $post_id, array( 'order' => 'ASC' ) );
+			
+				/**
+				 * Filters the revisions to be considered for deletion.
+				 *
+				 * @since 6.2.0
+				 *
+				 * @param WP_Post[] $revisions Array of revisions, or an empty array if none.
+				 * @param int       $post_id   The ID of the post to save as a revision.
+				 */
+				$revisions = apply_filters(
+					'wp_save_post_revision_revisions_before_deletion',
+					$revisions,
+					$post_id
+				);
+			
+				$delete = count( $revisions ) - $revisions_to_keep;
+			
+				if ($delete >= 1) {
+					$revisions = array_slice( $revisions, 0, $delete );
+				
+					for ( $i = 0; isset( $revisions[ $i ] ); $i++ ) {
+						if ( str_contains( $revisions[ $i ]->post_name, 'autosave' ) ) {
+							continue;
+						}
+				
+						wp_delete_post_revision( $revisions[ $i ]->ID );
+					}
 				}
-		
-				wp_delete_post_revision( $revisions[ $i ]->ID );
 			}
 		} else {
 			wp_delete_post($revision_id, true);


### PR DESCRIPTION
Fix handling when wp_revisions_to_keep() returns -1.