### PR TITLE
Fatal error opening revision editor with WP versions older than 6.4

### DIFF
--- a/admin/admin-init_rvy.php
+++ b/admin/admin-init_rvy.php
@@ -649,4 +649,36 @@ function rvy_order_types($types, $args = [])
 
 	return $ordered_types;
 }
+
+/**
+ * Wrapper for WP function wp_get_admin_notice(), which was introduced by WP 6.4.0
+ *
+ * @param string $message The message.
+ * @param array  $args {
+ *     Optional. An array of arguments for the admin notice. Default empty array.
+ *
+ *     @type string   $type               Optional. The type of admin notice.
+ *                                        For example, 'error', 'success', 'warning', 'info'.
+ *                                        Default empty string.
+ *     @type string[] $additional_classes Optional. A string array of class names. Default empty array.
+ * }
+ * @return string The markup for an admin notice.
+ */
+function rvy_get_admin_notice( $message, $args = array() ) {
+	if (function_exists('wp_get_admin_notice')) {
+		return wp_get_admin_notice($message, $args);
+	}
+
+	$classes    = 'notice';
+
+	if ( '' !== $type ) {
+		$classes .= ' notice-' . $type;
+	}
+
+	if ( is_array( $args['additional_classes'] ) && ! empty( $args['additional_classes'] ) ) {
+		$classes .= ' ' . implode( ' ', $args['additional_classes'] );
+	}
+
+	return sprintf( '<div class="%1$s">%2$s</div>', $classes, $message );
+}
 	

--- a/admin/post-editor-workflow-ui_rvy.php
+++ b/admin/post-editor-workflow-ui_rvy.php
@@ -33,7 +33,7 @@ class PostEditorWorkflowUI {
             'currentPostAuthor' => get_post_field('post_author', $published_post_id),
             'onApprovalCaption' => esc_html__('(on approval)', 'revisionary'),
             'saveRevisionTooltip' =>  htmlEntities(
-                wp_get_admin_notice(
+                rvy_get_admin_notice(
                     $revisionary->admin->tooltipText(
                         __('Save changes to continue.', 'revisionary'),
                         __('Please save changes to the revision before submitting it.', 'revisionary'),


### PR DESCRIPTION
Fixes #1785