### PR TITLE
Add changelog sync workflow

### DIFF
--- a/.github/workflows/sync-changelog.yml
+++ b/.github/workflows/sync-changelog.yml
@@ -1,0 +1,14 @@
+name: Sync Changelog
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync_changelog:
+    uses: publishpress/github-workflows/.github/workflows/sync-changelog.yml@v3
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Add the shared PublishPress changelog sync workflow.
- Trigger changelog sync when a release is published.
- Allow manual changelog sync runs from GitHub Actions.
- Inherit organization or repository secrets from the calling repository.

## Testing
- Not run; workflow-only change.