### PR TITLE
Allow disabling revisions per term (#19)

### DIFF
--- a/admin/admin-posts_rvy.php
+++ b/admin/admin-posts_rvy.php
@@ -211,7 +211,12 @@ class RevisionaryAdminPosts {
 			?>
 			<div class='error' style="padding-top: 10px; padding-bottom: 10px"><?php esc_html_e('The post already has a revision in process.', 'revisionary');?>
 			</div>
-			<?php	
+			<?php																		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
+    	} elseif ( !empty($_GET['revision_action']) && ('blocked_term_excluded' == $_GET['revision_action'] ) ) {
+			?>
+			<div class='error' style="padding-top: 10px; padding-bottom: 10px"><?php esc_html_e('Revisions are disabled for posts in this term.', 'revisionary');?>
+			</div>
+			<?php
     	}
     }
     

--- a/admin/options.php
+++ b/admin/options.php
@@ -264,7 +264,7 @@ if ( defined('RVY_CONTENT_ROLES') ) {
 
 $this->form_options = apply_filters('revisionary_option_sections', [
 'features' => [
-	'post_types' =>			 ['enabled_post_types', 'enabled_fields', 'enabled_post_types_archive', 'enabled_post_types_copy', 'enabled_fields_copy'],
+	'post_types' =>			 ['enabled_post_types', 'enabled_fields', 'enabled_post_types_archive', 'enabled_post_types_copy', 'enabled_fields_copy', 'revision_excluded_terms'],
 	'statuses' => 			 [true],
 	'archive' =>			 ['num_revisions', 'archive_postmeta', 'extended_archive', 'revision_archive_deletion', 'revision_restore_require_cap', 'past_revisions_order_by'],
 	'working_copy' =>		 ['copy_posts_capability', 'revisor_role_add_custom_rolecaps', 'revision_limit_per_post', 'revision_limit_compat_mode', 'submit_permission_enables_creation', 'allow_post_author_revision', 'create_revision_direct_link', 'query_loop_revision_editor_allowance', 'revision_unfiltered_html_check', 'auto_submit_revisions', 'auto_submit_revisions_any_user', 'caption_copy_as_edit', 'permissions_compat_mode', 'pending_revisions', 'revise_posts_capability', 'pending_revision_update_post_date', 'pending_revision_update_modified_date', 'scheduled_revisions', 'scheduled_publish_cron', 'async_scheduled_publish', 'wp_cron_usage_detected', 'scheduled_revision_update_post_date', 'scheduled_revision_update_modified_date', 'approve_button_verbose', 'trigger_post_update_actions', 'copy_revision_comments_to_post', 'show_current_revision_bar', 'rev_publication_delete_ed_comments', 'revision_statuses_noun_labels', 'revision_queue_capability', 'manage_unsubmitted_capability', 'revisor_lock_others_revisions', 'revisor_hide_others_revisions', 'admin_menu_pending_count_icon', 'front_end_indicator', 'admin_revisions_to_own_posts', 'view_filters_include_unsubmitted_revisions', 'deletion_queue', 'compare_revisions_direct_approval', 'use_publishpress_notifications', 'planner_notifications_access_limited', 'legacy_notifications', 'pending_rev_notify_admin', 'pending_rev_notify_author', 'revision_update_notifications', 'rev_approval_notify_admin', 'rev_approval_notify_author', 'rev_approval_notify_revisor', 'publish_scheduled_notify_admin', 'publish_scheduled_notify_author', 'publish_scheduled_notify_revisor', 'use_notification_buffer'],
@@ -739,6 +739,81 @@ if (empty(array_filter($revisionary->enabled_post_types))) {
 			endif; // displaying checkbox UI
 
 		} // end foreach src_otype
+		?>
+
+		<?php
+		$option_name = 'revision_excluded_terms';
+
+		$this->all_options []= $option_name;
+
+		$excluded_terms = rvy_get_option($option_name, $sitewide, $customize_defaults);
+		if (!is_array($excluded_terms)) {
+			$excluded_terms = [];
+		}
+
+		$term_taxonomies = get_taxonomies(['public' => true], 'object');
+		$term_taxonomy_names = [];
+
+		foreach ($term_taxonomies as $taxonomy_key => $taxonomy_obj) {
+			$term_taxonomy_names[$taxonomy_key] = $taxonomy_obj->labels->name;
+		}
+
+		$term_taxonomy_names = rvy_order_types($term_taxonomy_names, ['item_type' => 'taxonomy']);
+		?>
+		<br />
+		<h3 style="margin-top:0; margin-bottom:8px"><?php esc_html_e('Disable Revisions by Term', 'revisionary');?>
+		<?php
+		echo $revisionary->admin->tooltipText(												// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			'',
+			esc_html__('Disable the revision workflow for posts in the selected terms.', 'revisionary'),
+			true
+		);
+		?>
+		</h3>
+
+		<?php
+		if (empty($term_taxonomy_names)) :
+			?>
+			<p class="agp-vtight_input"><?php esc_html_e('No public taxonomies are available.', 'revisionary');?></p>
+			<?php
+		else :
+			foreach ($term_taxonomy_names as $taxonomy_key => $taxonomy_label) :
+				$taxonomy_obj = $term_taxonomies[$taxonomy_key];
+				$terms = get_terms([
+					'taxonomy'   => $taxonomy_key,
+					'hide_empty' => false,
+					'fields'     => 'id=>name',
+					'number'     => 0,
+				]);
+
+				if (is_wp_error($terms) || empty($terms)) {
+					continue;
+				}
+				?>
+				<div style="margin-bottom: 12px">
+				<strong><?php echo esc_html($taxonomy_obj->labels->name); ?></strong>
+				<?php
+				foreach ($terms as $term_id => $term_name) :
+					$term_id   = (int) $term_id;
+					$checked   = !empty($excluded_terms[$taxonomy_key]) && in_array($term_id, array_map('intval', (array) $excluded_terms[$taxonomy_key]), true);
+					$item_id   = $option_name . '-' . $taxonomy_key . '-' . $term_id;
+					$item_name = $option_name . '[' . $taxonomy_key . '][]';
+					?>
+					<div class="agp-vtight_input">
+					<input name="<?php echo esc_attr($item_name); ?>" type="hidden" value="0"/>
+					<label for="<?php echo esc_attr($item_id); ?>" title="<?php echo esc_attr($term_id); ?>">
+					<input name="<?php echo esc_attr($item_name); ?>" type="checkbox" id="<?php echo esc_attr($item_id); ?>"
+						value="<?php echo esc_attr($term_id); ?>" <?php checked(true, $checked); ?> />
+					<?php echo esc_html($term_name); ?>
+					</label>
+					</div>
+					<?php
+				endforeach;
+				?>
+				</div>
+				<?php
+			endforeach;
+		endif;
 		?>
 
 		<?php

--- a/defaults_rvy.php
+++ b/defaults_rvy.php
@@ -165,6 +165,7 @@ function rvy_default_options() {
 		'enable_classic_metaboxes' => 0,
 		'front_end_indicator' => 1,
 		'admin_menu_pending_count_icon' => 0,
+		'revision_excluded_terms' => [],
 	);
 
 	return $def;

--- a/rvy_init-functions.php
+++ b/rvy_init-functions.php
@@ -792,6 +792,14 @@ function rvy_post_revision_blocked($post, $args = []) {
 
 	$post_id = (is_scalar($post)) ? $post : $post->ID;
 
+	// Exclude revisions for posts that belong to a selected term.
+	if (rvy_post_is_term_excluded($post_id)) {
+		return [
+			'code'        => 'blocked_term_excluded',
+			'description' => __('Revisions are disabled for posts in this term.', 'revisionary'),
+		];
+	}
+
 	if ($limit_per_post = rvy_get_option('revision_limit_per_post')) {
 		if (rvy_get_post_meta($post_id, '_rvy_has_revisions')) {
 			if ('submitted' === $limit_per_post) {
@@ -826,6 +834,98 @@ function rvy_post_revision_blocked($post, $args = []) {
 	}
 
 	return false;
+}
+
+/**
+ * Whether a post is excluded from revisions because it belongs to a selected term.
+ *
+ * The stored option is keyed by taxonomy: $excluded = [ 'category' => [3, 7], ... ].
+ *
+ * @param int|WP_Post $post Post ID or object.
+ * @return bool True if the post belongs to an excluded term in any taxonomy.
+ */
+function rvy_post_is_term_excluded($post) {
+	$_post = (is_scalar($post)) ? get_post($post) : $post;
+
+	if (empty($_post) || empty($_post->post_type)) {
+		return false;
+	}
+
+	$excluded = rvy_get_option('revision_excluded_terms');
+
+	if (empty($excluded) || !is_array($excluded)) {
+		return false;
+	}
+
+	$post_taxonomies = get_object_taxonomies($_post->post_type);
+	if (empty($post_taxonomies)) {
+		return false;
+	}
+
+	foreach ($post_taxonomies as $taxonomy) {
+		if (empty($excluded[$taxonomy]) || !is_array($excluded[$taxonomy])) {
+			continue;
+		}
+
+		$post_term_ids = wp_get_object_terms($_post->ID, $taxonomy, ['fields' => 'ids']);
+		if (is_wp_error($post_term_ids) || empty($post_term_ids)) {
+			continue;
+		}
+
+		if (array_intersect(array_map('intval', $post_term_ids), array_map('intval', $excluded[$taxonomy]))) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * Sanitize the revision_excluded_terms setting (taxonomy slug => term IDs).
+ *
+ * Drops any taxonomy that is not a registered public taxonomy and any term ID
+ * that does not belong to its taxonomy, so stored data can be trusted at runtime.
+ *
+ * @param array $input Raw input, keyed by taxonomy slug.
+ * @return array Cleaned input: [ 'taxonomy' => [int, int, ...] ].
+ */
+function rvy_sanitize_excluded_terms($input) {
+	if (!is_array($input)) {
+		return [];
+	}
+
+	$public_taxonomies = get_taxonomies(['public' => true], 'names');
+
+	$clean = [];
+
+	foreach ($input as $taxonomy => $term_ids) {
+		$taxonomy = sanitize_key($taxonomy);
+
+		if (!$taxonomy || !in_array($taxonomy, $public_taxonomies, true)) {
+			continue;
+		}
+
+		$term_ids = array_filter(array_map('absint', (array) $term_ids));
+
+		if (empty($term_ids)) {
+			continue;
+		}
+
+		$existing = get_terms([
+			'taxonomy'   => $taxonomy,
+			'include'    => $term_ids,
+			'fields'     => 'ids',
+			'hide_empty' => false,
+		]);
+
+		if (is_wp_error($existing) || empty($existing)) {
+			continue;
+		}
+
+		$clean[$taxonomy] = array_values(array_map('intval', $existing));
+	}
+
+	return $clean;
 }
 
 if (!empty($_REQUEST['rvy_flush_flags'])) {

--- a/submittee_rvy.php
+++ b/submittee_rvy.php
@@ -58,7 +58,9 @@ class Revisionary_Submittee {
 
 			foreach ( $reviewed_options as $option_basename ) {
 				if (isset($_POST[$option_basename])) {
-					if (is_array($_POST[$option_basename])) {
+					if ('revision_excluded_terms' == $option_basename) {
+						$value = rvy_sanitize_excluded_terms($_POST[$option_basename]);
+					} elseif (is_array($_POST[$option_basename])) {
 						$value = array_map('sanitize_key', $_POST[$option_basename]);
 					} else {
 						if ('revision_editor_bg_color' == $option_basename) {


### PR DESCRIPTION
## Summary

Issue #19 asks to enable/disable revisions per type and per taxonomy. The per-post-type part already shipped. This adds the missing part: per-term exclusion.

A new "Disable Revisions by Term" section under Revisions > Settings > Features lets admins pick terms (per public taxonomy) whose posts are blocked from the revision workflow. Enforcement lives in the existing single gate `rvy_post_revision_blocked()`, so the block editor, classic editor, admin posts row action, the revision-create action, and the front-end admin bar all inherit it. A matching blocked notice is wired up for parity.

Fixes #19

## Changes

### Per-term gate (`rvy_init-functions.php`)

**Before:**
```php
$post_id = (is_scalar($post)) ? $post : $post->ID;

if ($limit_per_post = rvy_get_option('revision_limit_per_post')) {
```

**After:**
```php
$post_id = (is_scalar($post)) ? $post : $post->ID;

// Exclude revisions for posts that belong to a selected term.
if (rvy_post_is_term_excluded($post_id)) {
    return [
        'code'        => 'blocked_term_excluded',
        'description' => __('Revisions are disabled for posts in this term.', 'revisionary'),
    ];
}

if ($limit_per_post = rvy_get_option('revision_limit_per_post')) {
```

Plus two helpers: `rvy_post_is_term_excluded($post)` (returns false early if the option is empty, then intersects the post's terms against the stored list) and `rvy_sanitize_excluded_terms($input)` (drops unknown taxonomies and term IDs at the trust boundary).

**Why:** one guard in the shared gate every revision path already calls, instead of a guard per caller.

### Settings UI (`admin/options.php`)

Renders a "Disable Revisions by Term" block on the Features tab: a per-taxonomy list of term checkboxes (only public taxonomies, only taxonomies that have terms). Field name `revision_excluded_terms[{taxonomy}][]`, read via `rvy_get_option()`, registered in the `post_types` form_options section and pushed onto `all_options` so the existing save loop persists it.

**Why:** mirrors the existing per-post-type checkbox pattern, no new save plumbing.

### Default + sanitize (`defaults_rvy.php`, `submittee_rvy.php`)

- `rvy_default_options()` gets `'revision_excluded_terms' => []` (auto-included in the sitewide scope by existing logic).
- The save loop gets a dedicated branch for this key that calls `rvy_sanitize_excluded_terms()` before persisting.

### Blocked notice (`admin/admin-posts_rvy.php`)

Adds a `blocked_term_excluded` branch to `revision_action_notice()`, matching the existing `blocked_revision_limit` and `blocked_unfiltered` branches.

## Testing

**Test 1: per-term exclusion**
1. Go to Revisions > Settings > Features tab.
2. Under "Disable Revisions by Term", check a term in Categories (e.g. "Announcements"), Save Changes.
3. Edit a post in the "Announcements" category.
4. Result: no revision UI in block or classic editor, no "Submit Revision" row action on the posts list.
5. Remove the post from that category and edit again.
6. Result: revision UI returns.

**Test 2: edge cases**
1. Post in two categories, only one excluded.
2. Result: post is blocked (any-match).
3. Uncheck all terms, Save.
4. Result: nothing breaks, no posts blocked, default behavior restored.

## Notes

- Default is empty, so existing installs see no behavior change.
- PHP 7.2.5 compatible (no typed properties, no arrow functions, no null coalesce-assign).
- Security: nonce `rvy-update-options` and `manage_options` already cover the field; taxonomy slugs sanitized with `sanitize_key`, term IDs with `absint`, output escaped with `esc_html`/`esc_attr`.

## Screenshots
|Before|After|
|----|----|
|<img width="1037" height="682" alt="SCR-20260719-clcc" src="https://github.com/user-attachments/assets/70254857-349f-4be6-b2da-6a71af8e0dc6" />|<img width="956" height="869" alt="SCR-20260719-clhc" src="https://github.com/user-attachments/assets/686959de-38a1-46d3-a16d-0d23a2ea4fa5" />|